### PR TITLE
add Mega Menus to Pro Features

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "boldgrid-theme-framework",
-	"version": "2.18.2",
+	"version": "2.19.0-issue-5",
 	"description": "BoldGrid Theme Framework",
 	"main": "index.js",
 	"engines": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: news, blog, e-commerce, sticky-post, theme-options, threaded-comments, ful
 Requires PHP: 5.6
 Requires at least: 4.8
 Tested up to: 6.1
-Stable tag: 2.18.2
+Stable tag: 2.19.0-issue-5
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0-standalone.html
 

--- a/src/boldgrid-theme-framework.php
+++ b/src/boldgrid-theme-framework.php
@@ -3,7 +3,7 @@
  * Plugin Name: BoldGrid Theme Framework
  * Plugin URI: https://www.boldgrid.com/docs/configuration-file
  * Description: BoldGrid Theme Framework is a library that allows you to easily make BoldGrid themes. Please see our reference guide for more information: https://www.boldgrid.com/docs/configuration-file
- * Version: 2.18.2
+ * Version: 2.19.0-issue-5
  * Author: BoldGrid.com <wpb@boldgrid.com>
  * Author URI: https://www.boldgrid.com/
  * Text Domain: bgtfw

--- a/src/includes/configs/pro-feature-cards.config.php
+++ b/src/includes/configs/pro-feature-cards.config.php
@@ -9,29 +9,29 @@
  */
 
 return array(
-	'mega-menus'      => array(
+	'mega-menus'          => array(
 		'title'       => __( 'Mega Menus', 'crio' ),
 		'subtitle'    => __( 'Create custom WYSIWYG submenus with images, text, links, and more.', 'crio' ),
 		'icon'        => 'dashicons-welcome-widgets-menus',
 		'color'       => 'f75c27',
 		'show_notice' => 'mega-menus',
 	),
-	'custom-page-headers'     => array(
-		'title'      => __( 'Custom Page Headers', 'crio' ),
-		'subtitle'   => __( 'Create Page Headers using drag and drop functionality, and assign them to different areas.', 'crio' ),
-		'color'      => 'ca663b',
-		'icon'       => 'dashicons-table-row-before',
+	'custom-page-headers' => array(
+		'title'    => __( 'Custom Page Headers', 'crio' ),
+		'subtitle' => __( 'Create Page Headers using drag and drop functionality, and assign them to different areas.', 'crio' ),
+		'color'    => 'ca663b',
+		'icon'     => 'dashicons-table-row-before',
 	),
 	'sticky-headers'      => array(
-		'title'      => __( 'Sticky Headers', 'crio' ),
-		'subtitle'   => __( 'Create a sticky header with a different layout and menu than the standard header.', 'crio' ),
-		'icon'       => 'dashicons-cover-image',
-		'color'      => 'a8817b',
+		'title'    => __( 'Sticky Headers', 'crio' ),
+		'subtitle' => __( 'Create a sticky header with a different layout and menu than the standard header.', 'crio' ),
+		'icon'     => 'dashicons-cover-image',
+		'color'    => 'a8817b',
 	),
-	'more-customization'      => array(
-		'title'      => __( 'Blog Customization', 'crio' ),
-		'subtitle'   => __( 'Additional post header controls to further fine-tune your blog posts.', 'crio' ),
-		'icon'       => 'dashicons-welcome-write-blog',
-		'color'      => '4a93b6',
+	'more-customization'  => array(
+		'title'    => __( 'Blog Customization', 'crio' ),
+		'subtitle' => __( 'Additional post header controls to further fine-tune your blog posts.', 'crio' ),
+		'icon'     => 'dashicons-welcome-write-blog',
+		'color'    => '4a93b6',
 	),
 );

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Author: BoldGrid
 Theme URI: https://www.boldgrid.com/themes/crio/
 Author URI: https://www.boldgrid.com/
 Description: Crio is a WordPress SuperTheme that allows front-end designers, developers and other web professionals to create without bounds or restrictions.  Crio's advanced customization options are completely integrated with the WordPress Customizer API, providing you with a powerful, but familiar interface to customize your website. Our integration gives you granular control over many elements straight from the Customizer, and even device previews so you can see how your site looks on different devices. Crio’s unique color palette system keeps colors consistent across your site. Drag and drop colors in your palette to increase or decrease the usage of that color throughout your website. Use the advanced controls to create a custom Header, Footer, or Blog Page layout. Be Bold and stand above the rest with Prime by BoldGrid!
-Version: 2.18.2
+Version: 2.19.0-issue-5
 Requires at least: 5.5
 Tested up to: 6.1
 Requires PHP: 5.6


### PR DESCRIPTION
Resolves #5

Testing Instructions: 

[crio-2.19.0-issue-5.zip](https://github.com/BoldGrid/crio/files/10450225/crio-2.19.0-issue-5.zip)


1. Activate theme without Crio Pro installed.
2. Ensure the number '1' is shown under Crio > Pro Features.
3. View the Pro Features page, and ensure the first item shown is the 'Mega Menu' Card and that it has the 'New' banner.
4. Leave the page, or refresh, and ensure the 'New' banner disappears and that the '1' is no longer shown under Crio > Pro Features.