### PR TITLE
Remove links from page / post / blog / archive titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "boldgrid-theme-framework",
-	"version": "2.18.2",
+	"version": "2.19.0-issue-14",
 	"description": "BoldGrid Theme Framework",
 	"main": "index.js",
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "boldgrid-theme-framework",
-	"version": "2.19.0-issue-14",
+	"version": "2.19.0-beta1",
 	"description": "BoldGrid Theme Framework",
 	"main": "index.js",
 	"engines": {

--- a/prime/templates/entry-header-page.php
+++ b/prime/templates/entry-header-page.php
@@ -10,7 +10,21 @@ do_action( 'boldgrid_before_entry_title' ); ?>
 <div <?php BoldGrid::add_class( 'page_header_wrapper', [ 'page-header-wrapper' ] ); ?>>
 	<header <?php BoldGrid::add_class( 'page_page_title', [ 'entry-header', 'page-header', has_post_thumbnail( get_option( 'page_for_posts', true ) ) ? 'has-featured-image-header' : '' ] ); ?> <?php bgtfw_featured_img_bg( $post->ID ); ?>>
 		<div <?php BoldGrid::add_class( 'featured_image_page', [ 'featured-imgage-header' ] ); ?>>
-			<?php the_title( sprintf( '<p class="entry-title page-title ' . get_theme_mod( 'bgtfw_global_title_size' ) . '"><a ' . BoldGrid::add_class( 'pages_title', [ 'link' ], false ) . ' href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></p>' ); ?>
+			<?php
+			echo wp_kses_post(
+				sprintf(
+					// translators: %1$s is the element type, %2$s is the class string, %3$s is the title.
+					'<%1$s %2$s>%3$s</%1$s>',
+					apply_filters( 'bgtfw_page_title_element', 'p' ),
+					BoldGrid::add_class(
+						'pages_title',
+						array( 'entry-title', 'page-title', get_theme_mod( 'bgtfw_global_title_size' ) ),
+						false
+					),
+					get_the_title()
+				)
+			);
+			?>
 			<?php if ( 'post' == get_post_type() ) : ?>
 			<div class="entry-meta">
 				<?php boldgrid_posted_on(); ?>

--- a/prime/templates/entry-header-single.php
+++ b/prime/templates/entry-header-single.php
@@ -22,14 +22,18 @@ do_action( 'boldgrid_before_entry_title' ); ?>
 	>
 		<div <?php BoldGrid::add_class( 'featured_image_single', [ 'featured-imgage-header' ] ); ?>>
 			<?php
-			$title_element    = apply_filters( 'bgtfw_entry_title_element', 'p' );
-			$title_size       = get_theme_mod( 'bgtfw_global_title_size' );
-			$title_link_class = BoldGrid::add_class( 'posts_title', [ 'link' ], false );
-			$title_link_url   = esc_url( get_permalink() );
-
-			the_title(
-				'<' . $title_element . ' class="entry-title page-title ' . $title_size . '"><a ' . $title_link_class . ' href="' . $title_link_url . '" rel="bookmark">',
-				'</a></' . $title_element . '>'
+			echo wp_kses_post(
+				sprintf(
+					// translators: %1$s is the element type, %2$s is the class string, %3$s is the title.
+					'<%1$s %2$s>%3$s</%1$s>',
+					apply_filters( 'bgtfw_entry_title_element', 'p' ),
+					BoldGrid::add_class(
+						'pages_title',
+						array( 'entry-title', 'page-title', get_theme_mod( 'bgtfw_global_title_size' ) ),
+						false
+					),
+					get_the_title()
+				)
 			);
 			?>
 			<?php if ( 'post' == get_post_type() ) : ?>

--- a/prime/templates/page-header-archive.php
+++ b/prime/templates/page-header-archive.php
@@ -11,24 +11,19 @@
 	<header <?php BoldGrid::add_class( 'archive_page_title', [ 'page-header' ] ); ?>>
 		<div <?php BoldGrid::add_class( 'featured_image', [ 'featured-imgage-header' ] ); ?>>
 			<?php
-				$crio_queried_obj = get_queried_object_id();
-				$crio_archive_url = is_author() ? get_author_posts_url( $crio_queried_obj ) : get_term_link( $crio_queried_obj );
-				if ( ! is_wp_error( $crio_archive_url ) ) {
-					printf(
-						'<h1 class="page-title %1$s"><a %2$s href="%3$s" rel="bookmark">%4$s</a></h1>',
-						esc_attr( get_theme_mod( 'bgtfw_global_title_size' ) ),
-						BoldGrid::add_class( 'pages_title', [ 'link' ], false ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-						esc_url( $crio_archive_url ),
-						wp_kses_post( get_the_archive_title() )
-					);
-				} else {
-					printf(
-						'<h1 class="page-title %1$s"><span %2$s>%3$s</span></h1>',
-						esc_attr( get_theme_mod( 'bgtfw_global_title_size' ) ),
-						BoldGrid::add_class( 'pages_title', [ 'link' ], false ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-						wp_kses_post( get_the_archive_title() )
-					);
-				}
+				echo wp_kses_post(
+					sprintf(
+						// translators: %1$s is the element type, %2$s is the class string, %3$s is the title.
+						'<%1$s %2$s>%3$s</%1$s>',
+						apply_filters( 'bgtfw_archive_title_element', 'h1' ),
+						BoldGrid::add_class(
+							'pages_title',
+							array( 'page-title', esc_attr( get_theme_mod( 'bgtfw_global_title_size' ) ) ),
+							false
+						),
+						get_the_archive_title()
+					)
+				);
 
 				wp_kses_post( the_archive_description( '<div class="taxonomy-description">', '</div>' ) );
 			?>

--- a/prime/templates/page-header-blog.php
+++ b/prime/templates/page-header-blog.php
@@ -11,12 +11,18 @@
 	<header <?php BoldGrid::add_class( 'blog_page_title', [ 'page-header', has_post_thumbnail( get_option( 'page_for_posts', true ) ) ? 'has-featured-image-header' : '' ] ) ?> <?php bgtfw_featured_img_bg( get_option( 'page_for_posts', true ), true ); ?>>
 		<div <?php BoldGrid::add_class( 'featured_image', [ 'featured-imgage-header' ] ); ?>>
 			<?php
-				printf(
-					'<h1 class="page-title %1$s"><a %2$s href="%3$s" rel="bookmark">%4$s</a></h1>',
-					esc_attr( get_theme_mod( 'bgtfw_global_title_size' ) ),
-					BoldGrid::add_class( 'pages_title', [ 'link' ], false ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					esc_url( get_permalink( get_option( 'page_for_posts', true ) ) ),
-					wp_kses_post( get_the_title( get_option( 'page_for_posts', true ) ) )
+				echo wp_kses_post(
+					sprintf(
+						// translators: %1$s is the element type, %2$s is the class string, %3$s is the title.
+						'<%1$s %2$s>%3$s</%1$s>',
+						apply_filters( 'bgtfw_blog_title_element', 'h1' ),
+						BoldGrid::add_class(
+							'pages_title',
+							array( 'page-title', esc_attr( get_theme_mod( 'bgtfw_global_title_size' ) ) ),
+							false
+						),
+						get_the_title( get_option( 'page_for_posts', true ) )
+					)
 				);
 			?>
 		</div>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: news, blog, e-commerce, sticky-post, theme-options, threaded-comments, ful
 Requires PHP: 5.6
 Requires at least: 4.8
 Tested up to: 6.1
-Stable tag: 2.18.2
+Stable tag: 2.19.0-issue-14
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0-standalone.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: news, blog, e-commerce, sticky-post, theme-options, threaded-comments, ful
 Requires PHP: 5.6
 Requires at least: 4.8
 Tested up to: 6.1
-Stable tag: 2.19.0-issue-14
+Stable tag: 2.19.0-beta1
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0-standalone.html
 

--- a/src/assets/js/customizer/color/preview.js
+++ b/src/assets/js/customizer/color/preview.js
@@ -45,7 +45,7 @@ export class Preview  {
 			},
 			{
 				name: 'bgtfw_global_title_color',
-				selector: '.page-header .entry-title .link, .page-header .page-title .link',
+				selector: '.page-header .entry-title, .page-header .page-title',
 				properties: [ 'color', 'color-hover' ]
 			},
 			{

--- a/src/assets/js/customizer/customizer.js
+++ b/src/assets/js/customizer/customizer.js
@@ -1,5 +1,6 @@
 /* global _wpCustomizePreviewNavMenusExports:false, _wpCustomizeSettings:false, BoldGrid:true, BOLDGRID:true */
 import ColorPreview from './color/preview';
+import TitleSizePreview from './title-size/preview';
 import { Preview as GenericPreview } from './generic/preview.js';
 import { Preview as ResponsiveFontSizes } from './responsive-font-sizes/preview.js';
 import { Preview as HeaderPreview } from './header-layout/preview.js';
@@ -271,6 +272,8 @@ BOLDGRID.Customizer.Util.getInitialPalettes = function( option ) {
 		headerLayout = new HeaderLayout();
 
 	headerLayout.init();
+
+	new TitleSizePreview().init();
 
 	new ResponsiveFontSizes().bindEvents();
 	new GenericPreview().bindEvents();

--- a/src/assets/js/customizer/title-size/preview.js
+++ b/src/assets/js/customizer/title-size/preview.js
@@ -1,0 +1,51 @@
+import { Preview as PreviewUtility } from '../preview';
+
+export class Preview  {
+
+	constructor() {
+		this.previewUtility = new PreviewUtility();
+	}
+
+	/**
+	 * Class initialized.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return {Preview} Class instance.
+	 */
+	init() {
+		$( () => this._onLoad() );
+
+		return this;
+	}
+
+	/**
+	 * Events to run when the Dom loads.
+	 *
+	 * @since 2.0.0
+	 */
+	_onLoad() {
+
+		// Set Defaults.
+		this._bindGlobalPageTitles();
+	}
+
+	/**
+	 * Bind the event of the .entry-headers changing colors.
+	 *
+	 * @since 2.0.0
+	 */
+	_bindGlobalPageTitles() {
+		wp.customize( 'bgtfw_global_title_size', ( value ) => {
+			value.bind( newValue => {
+				var $pageTitle       = $( '.page-header .entry-title, .page-header .page-title' ),
+				classesToRemove  = [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ];
+
+				$( $pageTitle ).removeClass( classesToRemove );
+				$( $pageTitle ).addClass( newValue );
+			} );
+		} );
+	}
+}
+
+export default Preview;

--- a/src/assets/js/customizer/widget-preview.js
+++ b/src/assets/js/customizer/widget-preview.js
@@ -17,6 +17,10 @@ BOLDGRID.CUSTOMIZER = BOLDGRID.CUSTOMIZER || {};
 
 	onload = function() {
 		self.section_selector = create_sections_selector();
+
+		if ( ! wp.customizer ) {
+			return;
+		}
 		self.$previewer = $( wp.customize.previewer.container ).find( 'iframe' ).last().contents();
 		bind_section_hover();
 		bind_force_mouse_leave();

--- a/src/boldgrid-theme-framework.php
+++ b/src/boldgrid-theme-framework.php
@@ -3,7 +3,7 @@
  * Plugin Name: BoldGrid Theme Framework
  * Plugin URI: https://www.boldgrid.com/docs/configuration-file
  * Description: BoldGrid Theme Framework is a library that allows you to easily make BoldGrid themes. Please see our reference guide for more information: https://www.boldgrid.com/docs/configuration-file
- * Version: 2.19.0-issue-14
+ * Version: 2.19.0-beta1
  * Author: BoldGrid.com <wpb@boldgrid.com>
  * Author URI: https://www.boldgrid.com/
  * Text Domain: bgtfw

--- a/src/boldgrid-theme-framework.php
+++ b/src/boldgrid-theme-framework.php
@@ -3,7 +3,7 @@
  * Plugin Name: BoldGrid Theme Framework
  * Plugin URI: https://www.boldgrid.com/docs/configuration-file
  * Description: BoldGrid Theme Framework is a library that allows you to easily make BoldGrid themes. Please see our reference guide for more information: https://www.boldgrid.com/docs/configuration-file
- * Version: 2.18.2
+ * Version: 2.19.0-issue-14
  * Author: BoldGrid.com <wpb@boldgrid.com>
  * Author URI: https://www.boldgrid.com/
  * Text Domain: bgtfw

--- a/src/includes/configs/customizer/controls/page-title.controls.php
+++ b/src/includes/configs/customizer/controls/page-title.controls.php
@@ -69,14 +69,6 @@ return array(
 		'sanitize_callback' => function( $value, $settings ) {
 			return in_array( $value, array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ), true ) ? $value : $settings->default;
 		},
-		'js_vars'           => array(
-			array(
-				'element'       => '.page-header .entry-title, .page-header .page-title',
-				'function'      => 'html',
-				'attr'          => 'class',
-				'value_pattern' => 'entry-title $',
-			),
-		),
 	),
 	'bgtfw_global_title_alignment'            => array(
 		'type'              => 'radio-buttonset',

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Author: BoldGrid
 Theme URI: https://www.boldgrid.com/themes/crio/
 Author URI: https://www.boldgrid.com/
 Description: Crio is a WordPress SuperTheme that allows front-end designers, developers and other web professionals to create without bounds or restrictions.  Crio's advanced customization options are completely integrated with the WordPress Customizer API, providing you with a powerful, but familiar interface to customize your website. Our integration gives you granular control over many elements straight from the Customizer, and even device previews so you can see how your site looks on different devices. Crio’s unique color palette system keeps colors consistent across your site. Drag and drop colors in your palette to increase or decrease the usage of that color throughout your website. Use the advanced controls to create a custom Header, Footer, or Blog Page layout. Be Bold and stand above the rest with Prime by BoldGrid!
-Version: 2.18.2
+Version: 2.19.0-issue-14
 Requires at least: 5.5
 Tested up to: 6.1
 Requires PHP: 5.6

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Author: BoldGrid
 Theme URI: https://www.boldgrid.com/themes/crio/
 Author URI: https://www.boldgrid.com/
 Description: Crio is a WordPress SuperTheme that allows front-end designers, developers and other web professionals to create without bounds or restrictions.  Crio's advanced customization options are completely integrated with the WordPress Customizer API, providing you with a powerful, but familiar interface to customize your website. Our integration gives you granular control over many elements straight from the Customizer, and even device previews so you can see how your site looks on different devices. Crio’s unique color palette system keeps colors consistent across your site. Drag and drop colors in your palette to increase or decrease the usage of that color throughout your website. Use the advanced controls to create a custom Header, Footer, or Blog Page layout. Be Bold and stand above the rest with Prime by BoldGrid!
-Version: 2.19.0-issue-14
+Version: 2.19.0-beta1
 Requires at least: 5.5
 Tested up to: 6.1
 Requires PHP: 5.6


### PR DESCRIPTION
Resolves #14

[crio-2.19.0-issue-14.zip](https://github.com/BoldGrid/crio/files/10470173/crio-2.19.0-issue-14.zip)

### Testing Instructions ###

1. Install Crio and activate starter content ( or install an inspiration with a blog, then replace with this zip ).
2. Visit a page that shows the page title ( Standard page title, not a page title included in a Custom Page Header ).
3. Ensure that the page title appears as normal, but does not function as a link.
4. Visit the blog page and repeat Step 3.
5. Visit a single post and repeat Step 3.
6. Visit an archive page ( such as a category ) and repeat step 3.