### PR TITLE
Issue 39 - Fix Submenu Padding for first menu item

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .project
 .settings
 .qaconfig.json
+hover1.json
 node_modules
 bower_components
 /vendor/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "boldgrid-theme-framework",
-	"version": "2.19.1",
+	"version": "2.19.1-rc1",
 	"description": "BoldGrid Theme Framework",
 	"main": "index.js",
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "boldgrid-theme-framework",
-	"version": "2.19.1-issue-786",
+	"version": "2.19.1-issue-30",
 	"description": "BoldGrid Theme Framework",
 	"main": "index.js",
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "boldgrid-theme-framework",
-	"version": "2.19.1-rc1",
+	"version": "2.19.1-issue-786",
 	"description": "BoldGrid Theme Framework",
 	"main": "index.js",
 	"engines": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: news, blog, e-commerce, sticky-post, theme-options, threaded-comments, ful
 Requires PHP: 5.6
 Requires at least: 4.8
 Tested up to: 6.1
-Stable tag: 2.19.1-rc1
+Stable tag: 2.19.1-issue-786
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0-standalone.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: news, blog, e-commerce, sticky-post, theme-options, threaded-comments, ful
 Requires PHP: 5.6
 Requires at least: 4.8
 Tested up to: 6.1
-Stable tag: 2.19.1
+Stable tag: 2.19.1-rc1
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0-standalone.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: news, blog, e-commerce, sticky-post, theme-options, threaded-comments, ful
 Requires PHP: 5.6
 Requires at least: 4.8
 Tested up to: 6.1
-Stable tag: 2.19.1-issue-786
+Stable tag: 2.19.1-issue-30
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0-standalone.html
 

--- a/src/assets/scss/boldgrid/navigation/_base.scss
+++ b/src/assets/scss/boldgrid/navigation/_base.scss
@@ -267,7 +267,7 @@
 			.sm-clean.nw,
 			.sm-clean.sw {
 				&:not( .sm-vertical ) {
-					> li.menu-item:first-of-type a {
+					> li.menu-item:first-of-type > a {
 						padding-left: 0px;
 					}
 				}

--- a/src/boldgrid-theme-framework.php
+++ b/src/boldgrid-theme-framework.php
@@ -3,7 +3,7 @@
  * Plugin Name: BoldGrid Theme Framework
  * Plugin URI: https://www.boldgrid.com/docs/configuration-file
  * Description: BoldGrid Theme Framework is a library that allows you to easily make BoldGrid themes. Please see our reference guide for more information: https://www.boldgrid.com/docs/configuration-file
- * Version: 2.19.1
+ * Version: 2.19.1-rc1
  * Author: BoldGrid.com <wpb@boldgrid.com>
  * Author URI: https://www.boldgrid.com/
  * Text Domain: bgtfw

--- a/src/boldgrid-theme-framework.php
+++ b/src/boldgrid-theme-framework.php
@@ -3,7 +3,7 @@
  * Plugin Name: BoldGrid Theme Framework
  * Plugin URI: https://www.boldgrid.com/docs/configuration-file
  * Description: BoldGrid Theme Framework is a library that allows you to easily make BoldGrid themes. Please see our reference guide for more information: https://www.boldgrid.com/docs/configuration-file
- * Version: 2.19.1-rc1
+ * Version: 2.19.1-issue-786
  * Author: BoldGrid.com <wpb@boldgrid.com>
  * Author URI: https://www.boldgrid.com/
  * Text Domain: bgtfw

--- a/src/boldgrid-theme-framework.php
+++ b/src/boldgrid-theme-framework.php
@@ -3,7 +3,7 @@
  * Plugin Name: BoldGrid Theme Framework
  * Plugin URI: https://www.boldgrid.com/docs/configuration-file
  * Description: BoldGrid Theme Framework is a library that allows you to easily make BoldGrid themes. Please see our reference guide for more information: https://www.boldgrid.com/docs/configuration-file
- * Version: 2.19.1-issue-786
+ * Version: 2.19.1-issue-30
  * Author: BoldGrid.com <wpb@boldgrid.com>
  * Author URI: https://www.boldgrid.com/
  * Text Domain: bgtfw

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Author: BoldGrid
 Theme URI: https://www.boldgrid.com/themes/crio/
 Author URI: https://www.boldgrid.com/
 Description: Crio is a WordPress SuperTheme that allows front-end designers, developers and other web professionals to create without bounds or restrictions.  Crio's advanced customization options are completely integrated with the WordPress Customizer API, providing you with a powerful, but familiar interface to customize your website. Our integration gives you granular control over many elements straight from the Customizer, and even device previews so you can see how your site looks on different devices. Crio’s unique color palette system keeps colors consistent across your site. Drag and drop colors in your palette to increase or decrease the usage of that color throughout your website. Use the advanced controls to create a custom Header, Footer, or Blog Page layout. Be Bold and stand above the rest with Prime by BoldGrid!
-Version: 2.19.1-rc1
+Version: 2.19.1-issue-786
 Requires at least: 5.5
 Tested up to: 6.1
 Requires PHP: 5.6

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Author: BoldGrid
 Theme URI: https://www.boldgrid.com/themes/crio/
 Author URI: https://www.boldgrid.com/
 Description: Crio is a WordPress SuperTheme that allows front-end designers, developers and other web professionals to create without bounds or restrictions.  Crio's advanced customization options are completely integrated with the WordPress Customizer API, providing you with a powerful, but familiar interface to customize your website. Our integration gives you granular control over many elements straight from the Customizer, and even device previews so you can see how your site looks on different devices. Crio’s unique color palette system keeps colors consistent across your site. Drag and drop colors in your palette to increase or decrease the usage of that color throughout your website. Use the advanced controls to create a custom Header, Footer, or Blog Page layout. Be Bold and stand above the rest with Prime by BoldGrid!
-Version: 2.19.1-issue-786
+Version: 2.19.1-issue-30
 Requires at least: 5.5
 Tested up to: 6.1
 Requires PHP: 5.6

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Author: BoldGrid
 Theme URI: https://www.boldgrid.com/themes/crio/
 Author URI: https://www.boldgrid.com/
 Description: Crio is a WordPress SuperTheme that allows front-end designers, developers and other web professionals to create without bounds or restrictions.  Crio's advanced customization options are completely integrated with the WordPress Customizer API, providing you with a powerful, but familiar interface to customize your website. Our integration gives you granular control over many elements straight from the Customizer, and even device previews so you can see how your site looks on different devices. Crio’s unique color palette system keeps colors consistent across your site. Drag and drop colors in your palette to increase or decrease the usage of that color throughout your website. Use the advanced controls to create a custom Header, Footer, or Blog Page layout. Be Bold and stand above the rest with Prime by BoldGrid!
-Version: 2.19.1
+Version: 2.19.1-rc1
 Requires at least: 5.5
 Tested up to: 6.1
 Requires PHP: 5.6


### PR DESCRIPTION
ISSUE: Resolves #39

PROJECT: [Crio 2.19.1](https://github.com/orgs/BoldGrid/projects/13/views/9)
# {Description} #

## Test Files ##

[crio-2.19.1-issue-39.zip](https://github.com/BoldGrid/crio/files/10958824/crio-2.19.1-issue-39.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Setup a menu where the first item of the menu has a submenu.
3. Ensure that there as a left padding of 20px on each submenu item both while hovering and not hovering over the items.
