### PR TITLE
Separate Blog Post List Post Margin controls - Issue 38

### DIFF
--- a/src/assets/scss/boldgrid/_temp.scss
+++ b/src/assets/scss/boldgrid/_temp.scss
@@ -409,7 +409,7 @@
 	flex-wrap: wrap;
 	flex: 1 0 auto;
 	width: calc((100% / 1 - .5vw) - 2vw);
-	margin: 1vw;
+	margin: 0 1vw;
 }
 .page .page,
 .single .post {

--- a/src/includes/configs/customizer/controls/blog-page.controls.php
+++ b/src/includes/configs/customizer/controls/blog-page.controls.php
@@ -1869,6 +1869,42 @@ return array(
 		'section'           => 'bgtfw_layout_blog',
 		'sanitize_callback' => 'sanitize_html_class',
 	),
+	'bgtfw_blog_page_margin'                                => array(
+		'type'              => 'kirki-generic',
+		'transport'         => 'postMessage',
+		'section'           => 'bgtfw_blog_margin_section',
+		'settings'          => 'bgtfw_blog_page_margin',
+		'label'             => '',
+		'default'           => array(
+			array(
+				'media'    => array( 'base' ),
+				'unit'     => 'em',
+				'isLinked' => true,
+				'values'   => array(
+					'top' => 0,
+				),
+			),
+		),
+		'sanitize_callback' => array( 'Boldgrid_Framework_Customizer_Generic', 'sanitize' ),
+		'choices'           => array(
+			'name'     => 'boldgrid_controls',
+			'type'     => 'Padding',
+			'settings' => array(
+				'responsive' => Boldgrid_Framework_Customizer_Generic::$device_sizes,
+				'control'    => array(
+					'title'     => __( 'Margin Above Posts Container', 'crio' ),
+					'selectors' => array( '.archive .article-wrapper, .blog .article-wrapper' ),
+					'sliders'   => array(
+						array(
+							'name'        => 'top',
+							'label'       => '',
+							'cssProperty' => 'padding-top',
+						),
+					),
+				),
+			),
+		),
+	),
 	'bgtfw_blog_margin'                                => array(
 		'type'              => 'kirki-generic',
 		'transport'         => 'postMessage',
@@ -1894,15 +1930,11 @@ return array(
 				'responsive' => Boldgrid_Framework_Customizer_Generic::$device_sizes,
 				'control'    => array(
 					'selectors' => array( '.palette-primary.archive .post, .palette-primary.blog .post' ),
+					'title'     => __( 'Margin Between Posts', 'crio' ),
 					'sliders'   => array(
 						array(
-							'name'        => 'top',
-							'label'       => 'Top',
-							'cssProperty' => 'margin-top',
-						),
-						array(
 							'name'        => 'bottom',
-							'label'       => 'Bottom',
+							'label'       => '',
 							'cssProperty' => 'margin-bottom',
 						),
 					),

--- a/src/includes/configs/customizer/controls/blog-page.controls.php
+++ b/src/includes/configs/customizer/controls/blog-page.controls.php
@@ -1930,7 +1930,7 @@ return array(
 				'responsive' => Boldgrid_Framework_Customizer_Generic::$device_sizes,
 				'control'    => array(
 					'selectors' => array( '.palette-primary.archive .post, .palette-primary.blog .post' ),
-					'title'     => __( 'Margin Between Posts', 'crio' ),
+					'title'     => __( 'Margin Below Posts', 'crio' ),
 					'sliders'   => array(
 						array(
 							'name'        => 'bottom',


### PR DESCRIPTION
ISSUE: Resolves #38 

PROJECT: [Project #9](https://github.com/orgs/BoldGrid/projects/13/views/9)

# Separate Blog Post List Post Margin controls #

## Test Files ##

[crio-2.19.1-issue-38.zip](https://github.com/BoldGrid/crio/files/10973186/crio-2.19.1-issue-38.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Install Starter Content to install blog page and posts.
3. Open customizer, and navigate to `Design > Blog > Blog Page > Advanced > Margin`
4. Adjust the 'Margin Above Posts Container` and ensure that it only changes the spacing between the first post ( or first row of posts if multiple columns ). 
5. Adjust the `Margin Below Posts` and ensure that it only changes the spacing below posts.
6. Set the Margin on both controls to match, and ensure that the resulting spacing between the page title container and the first row of posts is equal to the spacing between each row of posts.
