### PR TITLE
Fix Blog Category links not working - Issue 37

### DIFF
--- a/src/includes/class-boldgrid-framework-404.php
+++ b/src/includes/class-boldgrid-framework-404.php
@@ -65,7 +65,6 @@ class BoldGrid_Framework_404 {
 
 						<?php the_widget( 'WP_Widget_Recent_Posts' ); ?>
 
-						<?php if ( boldgrid_categorized_blog() ) : // Only show the widget if site has multiple categories. ?>
 						<div class="widget widget_categories">
 							<h2 class="widget-title"><?php esc_html_e( 'Most Used Categories', 'crio' ); ?></h2>
 							<ul>
@@ -80,7 +79,6 @@ class BoldGrid_Framework_404 {
 							?>
 							</ul>
 						</div><!-- .widget -->
-						<?php endif; ?>
 
 						<?php
 							/* translators: %1$s: smiley */

--- a/src/includes/class-boldgrid-framework-comments.php
+++ b/src/includes/class-boldgrid-framework-comments.php
@@ -272,8 +272,6 @@ class BoldGrid_Framework_Comments {
 						$button_class = get_theme_mod( 'bgtfw_comment_reply_button_class', 'button-primary' );
 						$classes      = apply_filters( 'bgtfw_button_classes', array() );
 
-						error_log( 'button_class: ' . $button_class );
-						error_log( 'isset button_class: ' . isset( $classes[ $button_class ] ) );
 						if ( isset( $classes[ $button_class ] ) ) {
 							$comment_reply_link = preg_replace(
 								'/comment-reply-link/',

--- a/src/includes/class-boldgrid-framework.php
+++ b/src/includes/class-boldgrid-framework.php
@@ -656,6 +656,12 @@ class BoldGrid_Framework {
 		$this->loader->add_action( 'init', $admin, 'remove_hooks' );
 
 		$this->loader->add_action( 'bgtfw_pro_feature_cards', $pro_feature_cards, 'print_cards' );
+
+		// Filter category rewrite rules.
+		$this->loader->add_filter( 'category_rewrite_rules', $admin, 'category_rewrite_rules' );
+		$this->loader->add_action( 'created_category', $admin, 'schedule_flush' );
+		$this->loader->add_action( 'edited_category', $admin, 'schedule_flush' );
+		$this->loader->add_action( 'delete_category', $admin, 'schedule_flush' );
 	}
 
 	/**

--- a/src/includes/partials/template-tags.php
+++ b/src/includes/partials/template-tags.php
@@ -169,7 +169,7 @@ function boldgrid_entry_footer() {
 		$categories_list = get_the_category_list( esc_html__( ', ', 'crio' ) );
 		$categories_count = count( explode( ', ', $categories_list ) );
 
-		if ( $categories_list && boldgrid_categorized_blog() ) {
+		if ( $categories_list ) {
 			$class = 'singular';
 			$icon = is_single() ? get_theme_mod( 'bgtfw_posts_cat_icon' ) : get_theme_mod( 'bgtfw_blog_post_cat_icon' );
 
@@ -235,36 +235,6 @@ function boldgrid_entry_footer() {
 	bgtfw_edit_post_link();
 }
 endif;
-
-/**
- * Returns true if a blog has more than 1 category.
- *
- * @return bool
- */
-function boldgrid_categorized_blog() {
-	if ( false === ( $all_the_cool_cats = get_transient( 'boldgrid_categories' ) ) ) {
-		// Create an array of all the categories that are attached to posts.
-		$all_the_cool_cats = get_categories( array(
-			'fields'     => 'ids',
-			'hide_empty' => 1,
-			// We only need to know if there is more than one category.
-			'number'     => 2,
-		) );
-
-		// Count the number of categories that are attached to the posts.
-		$all_the_cool_cats = count( $all_the_cool_cats );
-
-		set_transient( 'boldgrid_categories', $all_the_cool_cats );
-	}
-
-	if ( $all_the_cool_cats > 1 ) {
-		// This blog has more than 1 category so boldgrid_categorized_blog should return true.
-		return true;
-	} else {
-		// This blog has only 1 category so boldgrid_categorized_blog should return false.
-		return false;
-	}
-}
 
 /**
  * Flush out the transients used in boldgrid_categorized_blog.


### PR DESCRIPTION
ISSUE: Resolves #37

PROJECT: [Crio 2.19.1](https://github.com/orgs/BoldGrid/projects/13/views/9)

# Fix Blog Category links not working #

## Test Files ##

[crio-2.19.1-issue-37.zip](https://github.com/BoldGrid/crio/files/11019214/crio-2.19.1-issue-37.zip)

## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install a theme using Inspirations.
2. Replace Crio with the zip file provided above
4. Ensure that category links display on the blog page. This will likely need to be enabled in the customizer.
5. Visit the blog page, and click on a category link. Ensure that it directs you to the category page, not to a 404 error page.
