### PR TITLE
Fix blog post next / previous not showing - Issue 44

### DIFF
--- a/src/includes/class-boldgrid-framework-api.php
+++ b/src/includes/class-boldgrid-framework-api.php
@@ -1512,4 +1512,54 @@ class BoldGrid {
 		$fixed_content = preg_replace( '/([a|li][^>]*class="[^"]*)button-secondary([^"]*")/', '$1button-secondary ' . $classes['button-secondary'] . '$2', $fixed_content );
 		return $fixed_content;
 	}
+
+	/**
+	 * Pagination Filters
+	 *
+	 * Filters the wp_query statements for
+	 * getting the 'next' and 'previous' posts.
+	 *
+	 * @since 2.19.1
+	 */
+	public function pagination_filters() {
+		add_filter(
+			'get_next_post_where',
+			function( $where, $in_same_term, $scluded_terms, $taxonomy, $post ) {
+				$where = str_replace( '>', '>=', $where );
+				$where = $where . ' AND p.ID > ' . $post->ID;
+				return $where;
+			},
+			10,
+			5
+		);
+
+		add_filter(
+			'get_next_post_sort',
+			function( $sort ) {
+				return 'ORDER BY p.post_date ASC, p.ID ASC LIMIT 1';
+			},
+			10,
+			1
+		);
+
+		add_filter(
+			'get_previous_post_where',
+			function( $where, $in_same_term, $scluded_terms, $taxonomy, $post ) {
+				$where = str_replace( '<', '<=', $where );
+				$where = $where . ' AND p.ID < ' . $post->ID;
+				return $where;
+			},
+			10,
+			5
+		);
+
+		add_filter(
+			'get_previous_post_sort',
+			function( $sort ) {
+				return 'ORDER BY p.post_date DESC, p.ID DESC LIMIT 1';
+			},
+			10,
+			1
+		);
+	}
 }

--- a/src/includes/class-boldgrid-framework.php
+++ b/src/includes/class-boldgrid-framework.php
@@ -478,6 +478,9 @@ class BoldGrid_Framework {
 		$this->loader->add_filter( 'bgtfw_blog_page_title_classes', $boldgrid_theme, 'page_title_background_class' );
 		$this->loader->add_filter( 'bgtfw_archive_page_title_classes', $boldgrid_theme, 'page_title_background_class' );
 
+		// Pagination Filters
+		$this->loader->add_action( 'after_setup_theme', $boldgrid_theme, 'pagination_filters' );
+
 		// Title containers.
 		$this->loader->add_filter( 'bgtfw_page_header_wrapper_classes', $boldgrid_theme, 'title_container' );
 		$this->loader->add_filter( 'bgtfw_featured_image_classes', $boldgrid_theme, 'title_content_container' );


### PR DESCRIPTION
ISSUE: Resolves #44 

PROJECT: [Crio 2.19.1](https://github.com/orgs/BoldGrid/projects/13/views/9)

# Fix blog post next / previous not showing #

## Test Files ##

[crio-2.19.1-issue-44.zip](https://github.com/BoldGrid/crio/files/11020756/crio-2.19.1-issue-44.zip)

## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install a NON DreamHost theme from Inspirations and ensure you enable the Blog option during installation.
2. Replace Crio with the zip file shown above
3. Visit a blog post, and ensure the post navigation links display as expected.4. 
