### PR TITLE
Issue 52 - add aria-hidden to taglines not shown

### DIFF
--- a/src/includes/class-boldgrid-framework-api.php
+++ b/src/includes/class-boldgrid-framework-api.php
@@ -108,8 +108,9 @@ class BoldGrid {
 	 */
 	public function print_tagline() {
 		// Retrieve blog tagline.
-		$blog_info = get_bloginfo( 'description' );
-		$display   = get_theme_mod( 'bgtfw_tagline_display' ) === 'hide' ? ' screen-reader-text' : '';
+		$blog_info   = get_bloginfo( 'description' );
+		$display     = get_theme_mod( 'bgtfw_tagline_display' ) === 'hide' ? ' screen-reader-text' : '';
+		$aria_hidden = ! in_array( 'description', get_theme_mod( 'bgtfw_header_preset_branding' ) ) ? 'true' : 'false';
 
 		if ( $blog_info ) {
 			$classes = $this->configs['template']['tagline-classes'] . $display;
@@ -117,7 +118,12 @@ class BoldGrid {
 			$classes = $this->configs['template']['tagline-classes'] . ' site-description invisible';
 		}
 
-		printf( wp_kses_post( $this->configs['template']['tagline'] ), esc_attr( $classes ), esc_html( $blog_info ) );
+		printf(
+			'<h3 class="site-description %1$s" aria-hidden="%2$s">%3$s</h3>',
+			esc_attr( $classes ),
+			esc_attr( $aria_hidden ),
+			esc_html( $blog_info )
+		);
 	}
 
 	/**


### PR DESCRIPTION
ISSUE: Resolves #52 

PROJECT: [Crio 2.20.0](https://github.com/orgs/BoldGrid/projects/13/views/9)

# add aria-hidden to taglines not shown #

## Test Files ##

[crio-2.20.0-issue-52.zip](https://github.com/BoldGrid/crio/files/11123304/crio-2.20.0-issue-52.zip)

## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Ensure that the Tagline is not displayed.
3. Inspect the header using Chrome DevTools, and ensure that the 'site-description' element has the aria-hidden=true attribute when it is not displayed.
4. Enable the tagline to be displayed in the customizer.
5. Inspect the header again and ensure that the aria-hidden=false attribute is set instead.
