### PR TITLE
Issue 49 - add notice to logo panel

### DIFF
--- a/src/assets/js/customizer/header-layout/header-layout.js
+++ b/src/assets/js/customizer/header-layout/header-layout.js
@@ -562,6 +562,18 @@ export class HeaderLayout  {
 			}
 		} );
 
+		controlApi.section( 'title_tagline' ).expanded.bind( ( isExpanded ) => {
+			if ( isExpanded ) {
+				this.brandingNotices( controlApi( 'bgtfw_header_preset_branding' )(), controlApi.control( 'custom_logo' ) );
+			}
+		} );
+
+		controlApi( 'custom_logo', ( control ) => {
+			control.bind( () => {
+				this.brandingNotices( controlApi( 'bgtfw_header_preset_branding' )(), controlApi.control( 'custom_logo' ) );
+			} );
+		} );
+
 		/*
 		 * bgtfw_header_presets
 		 *
@@ -1059,7 +1071,9 @@ export class HeaderLayout  {
 	 * @param {wp.customize.control} control Customizer Control object.
 	 */
 	brandingNotices( value, control ) {
-		var container = control.container;
+		var container = control.container,
+			controlId = control.id;
+
 		container.find( '.branding_notice' ).hide();
 
 		if ( value.includes( 'logo' ) && ! controlApi( 'custom_logo' )() ) {
@@ -1083,6 +1097,15 @@ export class HeaderLayout  {
 			container.find( '.branding_notice.description a' ).on( 'click', ( e ) => {
 				e.preventDefault();
 				controlApi.control( 'blogdescription' ).focus();
+			} );
+		}
+
+		if ( 'custom_logo' === controlId && ! value.includes( 'logo' ) && controlApi( 'custom_logo' )() ) {
+			container.find( '.branding_notice.logo_set' ).show();
+			container.find( '.branding_notice.logo_set a' ).off( 'click' );
+			container.find( '.branding_notice.logo_set a' ).on( 'click', ( e ) => {
+				e.preventDefault();
+				controlApi.control( 'bgtfw_header_preset_branding' ).focus();
 			} );
 		}
 	}

--- a/src/includes/customizer/class-boldgrid-framework-customizer-presets.php
+++ b/src/includes/customizer/class-boldgrid-framework-customizer-presets.php
@@ -111,6 +111,21 @@ class Boldgrid_Framework_Customizer_Presets {
 	}
 
 	/**
+	 * Get logo notice
+	 *
+	 * @since 2.20.0
+	 *
+	 * @return string Markup of notice
+	 */
+	public function get_logo_notice() {
+		return '<p class="branding_notice logo_set">'
+		. esc_html__( 'Your header layout does not display a logo. ', 'crio' )
+		. '<a href="#">' . esc_html__( 'Click Here', 'crio' )
+		. ' </a>' . esc_html__( ' to display your logo.', 'crio' )
+		. '</p>';
+		}
+
+	/**
 	 * Get Branding Notices.
 	 *
 	 * @since 2.7.0
@@ -122,6 +137,11 @@ class Boldgrid_Framework_Customizer_Presets {
 			. esc_html__( 'You do not have a logo set. ', 'crio' )
 			. '<a href="#">' . esc_html__( 'Click Here', 'crio' )
 			. ' </a>' . esc_html__( ' to set your logo.', 'crio' )
+			. '</p>';
+		$markup .= '<p class="branding_notice logo_set">'
+			. esc_html__( 'Your header layout does not display a logo. ', 'crio' )
+			. '<a href="#">' . esc_html__( 'Click Here', 'crio' )
+			. ' </a>' . esc_html__( ' to display your logo.', 'crio' )
 			. '</p>';
 		$markup .= '<p class="branding_notice title">'
 			. esc_html__( 'You do not have a site title set. ', 'crio' )

--- a/src/includes/customizer/class-boldgrid-framework-customizer.php
+++ b/src/includes/customizer/class-boldgrid-framework-customizer.php
@@ -838,6 +838,8 @@ HTML;
 
 		if ( $wp_customize->get_setting( 'custom_logo' ) ) {
 			$setting = $wp_customize->get_setting( 'custom_logo' );
+			$control = $wp_customize->get_control( 'custom_logo' );
+			$control->description = $this->presets->get_logo_notice();
 			$setting->transport = 'refresh';
 		}
 


### PR DESCRIPTION
ISSUE: Resolves #49 

PROJECT: [Crio 2.20.0](https://github.com/orgs/BoldGrid/projects/13/views/9)

# add notice to logo panel #

## Test Files ##

[crio-2.20.0-issue-49.zip](https://github.com/BoldGrid/crio/files/11123758/crio-2.20.0-issue-49.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. In the customizer, choose a header layout preset other than 'Default' or 'Custom'.
3. Uncheck 'logo' under the 'Branding Display' options.
4. Navigate to Design > Header > Site Logo
5. If a logo is set, there should be a notice shown indicating the the current header layout does not display a logo, and have a link to click on that will take you to the Branding Display control.
6. If a logo is NOT set, the notice will not show. In this case, set a logo, and ensure the notice shows. If a logo is removed, the notice should hide.
