### PR TITLE
fix missing CSS for post list widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Crio is a WordPress SuperTheme that allows front-end designers, developers and o
 
 ## Changelog ##
 
+### 2.20.1 ###
+* Bug Fix: Fix missing CSS for the PPB Post List widget when updating to 2.20.0.
+
 ### 2.20.0 ###
 * Enhancement: Improve Color Palettes by using color variables instead of SCSS compilation during runtime [#50](https://github.com/BoldGrid/crio/issues/50)
 * New Feature: Add notice to Design > Footer > Colors to help users [#48](https://github.com/BoldGrid/crio/issues/48)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "boldgrid-theme-framework",
-	"version": "2.20.0",
+	"version": "2.20.1",
 	"description": "BoldGrid Theme Framework",
 	"main": "index.js",
 	"engines": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: news, blog, e-commerce, sticky-post, theme-options, threaded-comments, ful
 Requires PHP: 5.6
 Requires at least: 4.8
 Tested up to: 6.2
-Stable tag: 2.20.0
+Stable tag: 2.20.1
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0-standalone.html
 
@@ -21,6 +21,9 @@ This version changes the way the color palette CSS is generated. If you are usin
 == Changelog ==
 
 ## Changelog ##
+
+== 2.20.1 ==
+* Bug Fix: Fix missing CSS for the PPB Post List widget when updating to 2.20.0.
 
 == 2.20.0 ==
 * Enhancement: Improve Color Palettes by using color variables instead of SCSS compilation during runtime [#50](https://github.com/BoldGrid/crio/issues/50)

--- a/src/assets/js/customizer/edit.js
+++ b/src/assets/js/customizer/edit.js
@@ -189,11 +189,14 @@ const { __ } = wp.i18n;
 				if ( 1 === Object.keys( controls ).length ) {
 					let controlId = Object.keys( controls )[0],
 						buttonPosition = self.determineButtonPosition( selector ),
-						thisLinkExclusions = [ '.button-primary', '.button-secondary', '.showcoupon', '.avatar', '.comment-edit-link' ].join( ', ' ),
+						thisLinkExclusions = [
+							'.button-primary', '.button-secondary', '.showcoupon', '.avatar', '.comment-edit-link',
+							'.bgc-single-title'
+						].join( ', ' ),
 						parentLinkExclusions = [
 							'.page-title', '.entry-title', '.tags-links', '.cat-links', '.read-more',
 							'.author', '.posted-on', '.nav-previous', '.nav-next', '.logged-in-as',
-							'.comment-meta', '.edit-link'
+							'.comment-meta', '.edit-link', '.bgc-single-article'
 						].join( ', ' );
 
 					$( selector ).each( function() {

--- a/src/assets/scss/boldgrid/_elements.scss
+++ b/src/assets/scss/boldgrid/_elements.scss
@@ -383,4 +383,18 @@ body.bgtfw-edit-links-hidden .bgtfw-edit-link a {
 	.color5-background-alpha {
 		background-color: rgba( var(--color-5-raw), 0.7 );
 	}
+
+	.boldgrid-shortcode .bgc-single-article {
+		background-color: var( --color-3 );
+		color: var( --color-3-text-contrast );
+	}
+  
+	.bgc-single-image .date {
+		background-color:rgba( var(--color-1-raw), 0.7 );
+		color: var( --color-1-text-contrast );
+	}
+  
+	.bgc-single-image .image-opacity {
+		background-color: rgba( var( --color-2-raw ), 0.3 );
+	}
 }

--- a/src/boldgrid-theme-framework.php
+++ b/src/boldgrid-theme-framework.php
@@ -3,7 +3,7 @@
  * Plugin Name: BoldGrid Theme Framework
  * Plugin URI: https://www.boldgrid.com/docs/configuration-file
  * Description: BoldGrid Theme Framework is a library that allows you to easily make BoldGrid themes. Please see our reference guide for more information: https://www.boldgrid.com/docs/configuration-file
- * Version: 2.20.0
+ * Version: 2.20.1
  * Author: BoldGrid.com <wpb@boldgrid.com>
  * Author URI: https://www.boldgrid.com/
  * Text Domain: bgtfw

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Author: BoldGrid
 Theme URI: https://www.boldgrid.com/themes/crio/
 Author URI: https://www.boldgrid.com/
 Description: Crio is a WordPress SuperTheme that allows front-end designers, developers and other web professionals to create without bounds or restrictions.  Crio's advanced customization options are completely integrated with the WordPress Customizer API, providing you with a powerful, but familiar interface to customize your website. Our integration gives you granular control over many elements straight from the Customizer, and even device previews so you can see how your site looks on different devices. Crio’s unique color palette system keeps colors consistent across your site. Drag and drop colors in your palette to increase or decrease the usage of that color throughout your website. Use the advanced controls to create a custom Header, Footer, or Blog Page layout. Be Bold and stand above the rest with Prime by BoldGrid!
-Version: 2.20.0
+Version: 2.20.1
 Requires at least: 5.5
 Tested up to: 6.2
 Requires PHP: 5.6


### PR DESCRIPTION
## Test Files ##
[crio-2.20.1.zip](https://github.com/BoldGrid/crio/files/11172413/crio-2.20.1.zip)


## Testing Instructions ##

1. Install the test zip files linked above.
2. Add a "Post List" widget to a page using PPB
3. Ensure that the following styles hold true:
* Background color below the post featured image uses color-3
* Background color of the date box in the top left uses color-1 at 70% alpha
* Background color overlaying the featured image uses color-2 at 30% alpha
4. Ensure that changing the colors in the palette accurately changes the colors in the widget
