### PR TITLE
Issue 60 - add blog post border radius control

### DIFF
--- a/src/assets/scss/boldgrid/blog/design/_base.scss
+++ b/src/assets/scss/boldgrid/blog/design/_base.scss
@@ -81,6 +81,7 @@ main {
 	article.post {
 		display: flex;
 		flex-direction: column;
+		overflow: hidden;
 		.entry-header {
 			display: flex;
 			flex-direction: column;

--- a/src/includes/configs/customizer/controls/blog-page.controls.php
+++ b/src/includes/configs/customizer/controls/blog-page.controls.php
@@ -1994,6 +1994,25 @@ return array(
 		),
 		'sanitize_callback' => array( $bgtfw_color_sanitize, 'sanitize_palette_selector' ),
 	),
+	'bgtfw_blog_border_radius'       => array(
+		'type'              => 'kirki-generic',
+		'transport'         => 'postMessage',
+		'section'           => 'bgtfw_blog_border_radius_section',
+		'settings'          => 'bgtfw_blog_border_radius',
+		'label'             => '',
+		'default'           => '',
+		'sanitize_callback' => array( 'Boldgrid_Framework_Customizer_Generic', 'sanitize' ),
+		'choices'           => array(
+			'name'     => 'boldgrid_controls',
+			'type'     => 'BorderRadius',
+			'settings' => array(
+				'responsive' => Boldgrid_Framework_Customizer_Generic::$device_sizes,
+				'control'    => array(
+					'selectors' => array( '.palette-primary.archive .post, .palette-primary.blog .post' ),
+				),
+			),
+		),
+	),
 	'bgtfw_blog_shadow'                                => array(
 		'type'              => 'kirki-generic',
 		'transport'         => 'postMessage',

--- a/src/includes/configs/customizer/sections.config.php
+++ b/src/includes/configs/customizer/sections.config.php
@@ -551,6 +551,13 @@ $sections_array = array(
 		'description' => esc_html__( 'Change the border of your blog posts.', 'crio' ),
 		'capability'  => 'edit_theme_options',
 	),
+	'bgtfw_blog_border_radius_section'                  => array(
+		'title'       => __( 'Border Radius', 'crio' ),
+		'panel'       => 'bgtfw_blog_blog_page_panel',
+		'section'     => 'bgtfw_pages_blog_blog_page_advanced',
+		'description' => esc_html__( 'Change the border radius of your blog posts.', 'crio' ),
+		'capability'  => 'edit_theme_options',
+	),
 	'bgtfw_blog_shadow_section'                  => array(
 		'title'       => __( 'Box Shadow', 'crio' ),
 		'panel'       => 'bgtfw_blog_blog_page_panel',


### PR DESCRIPTION
ISSUE: Resolves #60 

PROJECT: [${link to project}](https://github.com/orgs/BoldGrid/projects/13/views/9)

#  add blog post border radius control #

## Test Files ##

{LINK TO TEST ZIP FILES HERE}

## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Ensure you have a blog page with some posts
3. Open the Customizer, then go to your blog page.
4. Navigate the customizer controls to 'Design > Blog > Blog Page > Advanced > Border Radius
5. Set a border radius, and ensure it is displaying as expected. You may need to set a border or background color to the blog posts to get the border radius to be visible
