### PR TITLE
Issue 66 - Fix Transparent color palette issues

### DIFF
--- a/src/includes/class-boldgrid-framework-compile-colors.php
+++ b/src/includes/class-boldgrid-framework-compile-colors.php
@@ -634,7 +634,7 @@ class Boldgrid_Framework_Compile_Colors {
 		$r = intval( $rgba_array[0] );
 		$g = intval( $rgba_array[1] );
 		$b = intval( $rgba_array[2] );
-		$a = isset( $rgba_array[3] ) ? intval( $rgba_array[3] ) : 1;
+		$a = isset( $rgba_array[3] ) ? $rgba_array[3] : 1;
 
 		$r /= 255;
 		$g /= 255;

--- a/src/includes/class-boldgrid-framework-styles.php
+++ b/src/includes/class-boldgrid-framework-styles.php
@@ -619,7 +619,7 @@ class BoldGrid_Framework_Styles {
 				$dark_hsla_array    = $helper->rgba_to_hsla( $value_rgba_array, -10 );
 				$darker_hsla_array  = $helper->rgba_to_hsla( $value_rgba_array, -20 );
 
-				$value_raw      = str_replace( array( 'rgb(', ')' ), array( '', '' ), $value );
+				$value_raw      = "$value_rgba_array[0], $value_rgba_array[1], $value_rgba_array[2]";
 				$value_light    = 'hsla(' . implode( ',', $light_hsla_array ) . ')';
 				$value_lighter  = 'hsla(' . implode( ',', $lighter_hsla_array ) . ')';
 				$value_dark     = 'hsla(' . implode( ',', $dark_hsla_array ) . ')';


### PR DESCRIPTION
ISSUE: Resolves #66 

PROJECT: [Crio 2.20.0](https://github.com/orgs/BoldGrid/projects/13/views/9)

# Fix Transparent color palette issues #

## Test Files ##

[crio-2.20.2-issue-66.zip](https://github.com/BoldGrid/crio/files/11385330/crio-2.20.2-issue-66.zip)

## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Go to Customize → Color Palette
3. Click on any color in the palette
4. set the alpha slider to any value below 100
5. Publish and refresh
6. Ensure that the color palette CSS does not break. See [images in the ticket itself for reference](https://github.com/BoldGrid/crio/issues/66).
