### PR TITLE
woocommerce template updates

### DIFF
--- a/prime/woocommerce/loop/no-products-found.php
+++ b/prime/woocommerce/loop/no-products-found.php
@@ -10,14 +10,14 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author 		WooThemes
- * @package 	WooCommerce/Templates
- * @version     2.0.0
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates
+ * @version 7.8.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
-}
+defined( 'ABSPATH' ) || exit;
 
-wc_print_notice( __( 'No products were found matching your selection.', 'crio' ), 'notice' );
+?>
+<div class="woocommerce-no-products-found">
+	<?php wc_print_notice( esc_html__( 'No products were found matching your selection.', 'crio' ), 'notice' ); ?>
+</div>

--- a/prime/woocommerce/myaccount/downloads.php
+++ b/prime/woocommerce/myaccount/downloads.php
@@ -12,10 +12,9 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	https://docs.woocommerce.com/document/template-structure/
- * @author  WooThemes
- * @package WooCommerce/Templates
- * @version 3.2.0
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates
+ * @version 7.8.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -24,6 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $downloads     = WC()->customer->get_downloadable_products();
 $has_downloads = (bool) $downloads;
+
 do_action( 'woocommerce_before_account_downloads', $has_downloads ); ?>
 
 <?php if ( $has_downloads ) : ?>
@@ -35,12 +35,13 @@ do_action( 'woocommerce_before_account_downloads', $has_downloads ); ?>
 	<?php do_action( 'woocommerce_after_available_downloads' ); ?>
 
 <?php else : ?>
-	<div class="alert alert-info alert-white rounded">
-		<a class="woocommerce-Button button" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
-			<?php esc_html_e( 'Go shop', 'crio' ) ?>
-		</a>
-		<?php esc_html_e( 'No downloads available yet.', 'crio' ); ?>
-	</div>
+
+	<?php
+
+	$wp_button_class = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '';
+	wc_print_notice( esc_html__( 'No downloads available yet.', 'crio' ) . ' <a class="button wc-forward' . esc_attr( $wp_button_class ) . '" href="' . esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ) . '">' . esc_html__( 'Browse products', 'crio' ) . '</a>', 'notice' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment 
+	?>
+
 <?php endif; ?>
 
 <?php do_action( 'woocommerce_after_account_downloads', $has_downloads ); ?>

--- a/prime/woocommerce/myaccount/orders.php
+++ b/prime/woocommerce/myaccount/orders.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Orders
  *
@@ -15,7 +14,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.0.1
+ * @version 7.8.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -67,8 +66,8 @@ do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
 								$actions = wc_get_account_orders_actions( $order );
 
 								if ( ! empty( $actions ) ) {
-									foreach ( $actions as $key => $action ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
-										echo '<a href="' . esc_url( $action['url'] ) . '" class="woocommerce-button btn button-primary ' . sanitize_html_class( $key ) . '">' . esc_html( $action['name'] ) . '</a>';
+									foreach ( $actions as $key => $action ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+										echo '<a href="' . esc_url( $action['url'] ) . '" class="woocommerce-button' . esc_attr( $wp_button_class ) . ' button ' . sanitize_html_class( $key ) . '">' . esc_html( $action['name'] ) . '</a>';
 									}
 								}
 								?>
@@ -87,22 +86,19 @@ do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
 	<?php if ( 1 < $customer_orders->max_num_pages ) : ?>
 		<div class="woocommerce-pagination woocommerce-pagination--without-numbers woocommerce-Pagination">
 			<?php if ( 1 !== $current_page ) : ?>
-				<a class="woocommerce-button woocommerce-button--previous woocommerce-Button woocommerce-Button--previous btn button-primary" href="<?php echo esc_url( wc_get_endpoint_url( 'orders', $current_page - 1 ) ); ?>"><?php esc_html_e( 'Previous', 'crio' ); ?></a>
+				<a class="woocommerce-button woocommerce-button--previous woocommerce-Button woocommerce-Button--previous button<?php echo esc_attr( $wp_button_class ); ?>" href="<?php echo esc_url( wc_get_endpoint_url( 'orders', $current_page - 1 ) ); ?>"><?php esc_html_e( 'Previous', 'crio' ); ?></a>
 			<?php endif; ?>
 
 			<?php if ( intval( $customer_orders->max_num_pages ) !== $current_page ) : ?>
-				<a class="woocommerce-button woocommerce-button--next woocommerce-Button woocommerce-Button--next btn button-primary" href="<?php echo esc_url( wc_get_endpoint_url( 'orders', $current_page + 1 ) ); ?>"><?php esc_html_e( 'Next', 'crio' ); ?></a>
+				<a class="woocommerce-button woocommerce-button--next woocommerce-Button woocommerce-Button--next button<?php echo esc_attr( $wp_button_class ); ?>" href="<?php echo esc_url( wc_get_endpoint_url( 'orders', $current_page + 1 ) ); ?>"><?php esc_html_e( 'Next', 'crio' ); ?></a>
 			<?php endif; ?>
 		</div>
 	<?php endif; ?>
 
 <?php else : ?>
-	<div class="woocommerce-message woocommerce-message--info woocommerce-Message woocommerce-Message--info woocommerce-info">
-		<a class="woocommerce-Button btn button-primary" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
-			<?php esc_html_e( 'Browse products', 'crio' ); ?>
-		</a>
-		<?php esc_html_e( 'No order has been made yet.', 'crio' ); ?>
-	</div>
+
+	<?php wc_print_notice( esc_html__( 'No order has been made yet.', 'crio' ) . ' <a class="woocommerce-Button button' . esc_attr( $wp_button_class ) . '" href="' . esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ) . '">' . esc_html__( 'Browse products', 'crio' ) . '</a>', 'notice' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment ?>
+
 <?php endif; ?>
 
 <?php do_action( 'woocommerce_after_account_orders', $has_orders ); ?>


### PR DESCRIPTION
ISSUE: Resolves WooCommerce Template Updates

PROJECT: [${link to project}](https://github.com/BoldGrid/crio/issues/89)

Users reporting outdated WooCommerce templates

To Reproduce
Install Crio and WooCommerce and warning message will appear in Dashboard.

crio/woocommerce/loop/no-products-found.php version 2.0.0 is out of date. The core version is 7.8.0, 
crio/woocommerce/myaccount/downloads.php version 3.2.0 is out of date. The core version is 7.8.0, 
crio/woocommerce/myaccount/orders.php version 7.0.1 is out of date. The core version is 7.8.0, 
