### PR TITLE
Fix hvr-underline on submenus

### DIFF
--- a/src/assets/scss/boldgrid/navigation/_base.scss
+++ b/src/assets/scss/boldgrid/navigation/_base.scss
@@ -808,10 +808,20 @@
 	}
 }
 
-li.menu-item[class*="hvr-underline"]:not(.hvr-underline-reveal) a:not( .button-primary):not(.button-secondary ) {
-	transform: unset;
-	overflow: unset;
-	&:before {
-		bottom: -2.5px;
+li.menu-item[class*="hvr-underline"] {
+	> a:not( .button-primary):not( .button-secondary ) {
+		&:before {
+			z-index: 1;
+		}
+	}
+	&:not(.hvr-underline-reveal) a:not( .button-primary):not(.button-secondary ) {
+		transform: unset;
+		overflow: unset;
+		&:before {
+			bottom: -2.5px;
+		}
 	}
 }
+
+
+


### PR DESCRIPTION
ISSUE: Resolves #87 

PROJECT: [#13](https://github.com/orgs/BoldGrid/projects/13/views/14)

# Fix hvr-underline on submenus #

## Test Files ##

[crio-2.21.2-issue-87.zip](https://github.com/BoldGrid/crio/files/13031746/crio-2.21.2-issue-87.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Create a menu with at least one menu item having a submenu / dropdown menu with 2 or more items: Example shown below:
![image](https://github.com/BoldGrid/crio/assets/49331357/1816967c-6a76-4b68-b3c3-ac8d68567b1f)
3. Set the hover effect to one of the underline effects ( underline reveal, underline from center, etc ).
4. Ensure that the effect is seen on all the submenu items, not just the last one.
