### PR TITLE
fix fade menu not working on submenus

### DIFF
--- a/src/assets/js/customizer/color/preview.js
+++ b/src/assets/js/customizer/color/preview.js
@@ -435,17 +435,6 @@ export class Preview  {
 
 		css += '@media (min-width: 768px) {';
 		css += `#${location}-menu.sm-clean ul.sub-menu:not(.custom-sub-menu) {background-color: ${subcolorVariable};}`;
-		css += `#${location}-menu.sm-clean ul.sub-menu:not(.custom-sub-menu) li.menu-item:not(.custom-sub-menu) > a,
-			#${location}-menu.sm-clean ul.sub-menu:not(.custom-sub-menu) li.menu-item:not(.custom-sub-menu) > a:hover,
-			#${location}-menu.sm-clean ul.sub-menu:not(.custom-sub-menu) li.menu-item:not(.custom-sub-menu) > a:focus,
-			#${location}-menu.sm-clean ul.sub-menu:not(.custom-sub-menu) li.menu-item:not(.custom-sub-menu) > a:active,
-			#${location}-menu.sm-clean ul.sub-menu:not(.custom-sub-menu) li.menu-item:not(.custom-sub-menu) > a.highlighted,
-			#${location}-menu.sm-clean span.scroll-up,
-			#${location}-menu.sm-clean span.scroll-down,
-			#${location}-menu.sm-clean span.scroll-up:hover,
-			#${location}-menu.sm-clean span.scroll-down:hover {
-				background-color: ${subcolorVariable};
-			}`;
 		css += `#${location}-menu.sm-clean ul.sub-menu:not(.custom-sub-menu) {
 			border: 1px solid ${subcolorVariable};
 			}`;

--- a/src/assets/js/customizer/customizer.js
+++ b/src/assets/js/customizer/customizer.js
@@ -755,7 +755,7 @@ BOLDGRID.Customizer.Util.getInitialPalettes = function( option ) {
 				} );
 
 				// Bind menu items hover effects.
-				new ToggleValue( `bgtfw_menu_items_hover_effect_${props.theme_location}`, `#${props.menu_id} > li:not(.current-menu-item)`, hoverFn );
+				new ToggleValue( `bgtfw_menu_items_hover_effect_${props.theme_location}`, `#${props.menu_id} li:not(.current-menu-item)`, hoverFn );
 
 				// Bind menu background contrast for link colors.
 				api( `bgtfw_menu_background_${props.theme_location}`, 'bgtfw_header_color', 'bgtfw_footer_color', ( ...args ) => {

--- a/src/assets/js/customizer/menus/hover-background-toggle.js
+++ b/src/assets/js/customizer/menus/hover-background-toggle.js
@@ -57,7 +57,11 @@ export class HoverBackgroundToggle {
 								let currentChoice = api.control( effectControlId ).setting.get();
 
 								// Displays "Secondary Color" control for "Border Effects" (optgroup3) and "Two Color Transitions" (optgroup2) option groups.
-								_.isUndefined( choices.optgroup2[1][ currentChoice ] ) && _.isUndefined( choices.optgroup3[1][ currentChoice ] ) ? control.container.hide() : control.container.show();
+								_.isUndefined( choices.optgroup2[1][ currentChoice ] ) &&
+								_.isUndefined( choices.optgroup1[1][ currentChoice ] ) &&
+								_.isUndefined( choices.optgroup3[1][ currentChoice ] ) ?
+								control.container.hide() :
+								control.container.show();
 							};
 							display();
 							setting.bind( display );

--- a/src/includes/class-boldgrid-framework-styles.php
+++ b/src/includes/class-boldgrid-framework-styles.php
@@ -398,7 +398,7 @@ class BoldGrid_Framework_Styles {
 		$background_color = "var(--{$background_color})";
 
 		$location = str_replace( '_', '-', $location );
-		$menu_id = "#{$location}-menu";
+		$menu_id = "#{$location}-menu.sm-clean";
 
 		$css = include $this->configs['framework']['includes_dir'] . 'partials/hover-colors-only.php';
 		$css = sprintf( $css, $menu_id, $background_color, $color, $background_color );
@@ -532,11 +532,11 @@ class BoldGrid_Framework_Styles {
 		$subcolor_obj->alpha = 0.4;
 
 		$css .= "#{$location}-menu.sm-clean ul.sub-menu:not(.custom-sub-menu) {background-color: var(--{$submenu_background_class});}";
-		$css .= "#{$location}-menu.sm-clean ul.sub-menu:not(.custom-sub-menu) li.menu-item:not(.custom-sub-menu) > a:not(.btn), ";
-		$css .= "#{$location}-menu.sm-clean ul.sub-menu:not(.custom-sub-menu) li.menu-item:not(.custom-sub-menu) > a:not(.btn):hover, ";
-		$css .= "#{$location}-menu.sm-clean ul.sub-menu:not(.custom-sub-menu) li.menu-item:not(.custom-sub-menu) > a:not(.btn):focus, ";
-		$css .= "#{$location}-menu.sm-clean ul.sub-menu:not(.custom-sub-menu) li.menu-item:not(.custom-sub-menu) > a:not(.btn):active, ";
-		$css .= "#{$location}-menu.sm-clean ul.sub-menu:not(.custom-sub-menu) li.menu-item:not(.custom-sub-menu) > a:not(.btn).highlighted, ";
+		$css .= "#{$location}-menu.sm-clean ul.sub-menu:not(.custom-sub-menu) li.menu-item:not(.custom-sub-menu):not(.hvr-fade) > a:not(.btn), ";
+		$css .= "#{$location}-menu.sm-clean ul.sub-menu:not(.custom-sub-menu) li.menu-item:not(.custom-sub-menu):not(.hvr-fade) > a:not(.btn):hover, ";
+		$css .= "#{$location}-menu.sm-clean ul.sub-menu:not(.custom-sub-menu) li.menu-item:not(.custom-sub-menu):not(.hvr-fade) > a:not(.btn):focus, ";
+		$css .= "#{$location}-menu.sm-clean ul.sub-menu:not(.custom-sub-menu) li.menu-item:not(.custom-sub-menu):not(.hvr-fade) > a:not(.btn):active, ";
+		$css .= "#{$location}-menu.sm-clean ul.sub-menu:not(.custom-sub-menu) li.menu-item:not(.custom-sub-menu):not(.hvr-fade) > a:not(.btn).highlighted, ";
 		$css .= "#{$location}-menu.sm-clean span.scroll-up, #{$location}-menu.sm-clean span.scroll-down, ";
 		$css .= "#{$location}-menu.sm-clean span.scroll-up:hover, #{$location}-menu.sm-clean span.scroll-down:hover ";
 		$css .= "{ background-color: var(--{$submenu_background_class}); }";


### PR DESCRIPTION
ISSUE: Resolves #26 

PROJECT: [#13](https://github.com/orgs/BoldGrid/projects/13/views/14)
# fix fade menu not working on submenus #

## Test Files ##

[crio-2.21.2-issue-26.zip](https://github.com/BoldGrid/crio/files/13032344/crio-2.21.2-issue-26.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Create a menu with at least one menu item having a submenu / dropdown menu with 2 or more items: Example shown below:
![image](https://github.com/BoldGrid/crio/assets/49331357/1816967c-6a76-4b68-b3c3-ac8d68567b1f)
3. Set the hover effect to fade.
4. Ensure that the fade effect is seen on all sub-menu items