### PR TITLE
remove width: 100% from sticky logo

### DIFF
--- a/src/assets/scss/boldgrid/header/_slide-in.scss
+++ b/src/assets/scss/boldgrid/header/_slide-in.scss
@@ -33,10 +33,6 @@
 			.custom-logo-link {
 				margin-top: 10px;
 				margin-bottom: 10px;
-
-				.custom-logo {
-					width: 100%;
-				}
 			}
 		}
 	}


### PR DESCRIPTION
ISSUE: Resolves #99
PROJECT: [#13](https://github.com/orgs/BoldGrid/projects/13/views/9)

# remove width: 100% from sticky logo #

## Test Files ##

[crio-2.21.2-issue-99.zip](https://github.com/BoldGrid/crio/files/13191402/crio-2.21.2-issue-99.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Add a logo to a sticky CPH
3. Ensure that it is size restricted based on your customizer settings, rather than stretched to 100%
