### PR TITLE
add template-sticky-header to typography control

### DIFF
--- a/src/includes/configs/customizer/controls/typography.controls.php
+++ b/src/includes/configs/customizer/controls/typography.controls.php
@@ -77,7 +77,7 @@ return array(
 		'priority'  => 1,
 		'output'    => $bgtfw_typography->get_typography_output(
 			$bgtfw_configs,
-			'.widget, .site-content, .sm li.custom-sub-menu, .sm li.custom-sub-menu a:not(.btn), .sm li.custom-sub-menu .widget a:not(.btn), .attribution-theme-mods-wrapper, .gutenberg .edit-post-visual-editor, .mce-content-body, .template-header, .template-footer'
+			'.widget, .site-content, .sm li.custom-sub-menu, .sm li.custom-sub-menu a:not(.btn), .sm li.custom-sub-menu .widget a:not(.btn), .attribution-theme-mods-wrapper, .gutenberg .edit-post-visual-editor, .mce-content-body, .template-header, .template-sticky-header, .template-footer'
 		),
 		'edit_vars' => array(
 			array(


### PR DESCRIPTION
ISSUE: Resolves #101

PROJECT: [#13](https://github.com/orgs/BoldGrid/projects/13/views/9)

# add template-sticky-header to typography control #

## Test Files ##

[crio-2.21.2-issue-101.zip](https://github.com/BoldGrid/crio/files/13191601/crio-2.21.2-issue-101.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Create a Sticky CPH with a <p> element in it.
3. Ensure that it reflects the body typography settings ( font family, size, etc
