### PR TITLE
fix comment header being overridden by currentcolor

### DIFF
--- a/src/assets/scss/custom-color/color-palettes.scss
+++ b/src/assets/scss/custom-color/color-palettes.scss
@@ -188,12 +188,14 @@ $names: background background-color;
 		.color-neutral-#{nth($names, $i)} {
 			@for $each from 1 through length( $colors) {
 				&.color-#{$each}-link-color {
-					a {
+					a:not(.btn) {
 						color: var(--color-#{$each});
 					}
 					&:not( .sidebar ) {
-						a:hover, a:focus, a:active, a.highlighted {
-							color: var(--bg-neutral-text-#{$each}-hover);
+						a:not(.btn) {
+							&:hover, &:focus, &:active, &.highlighted {
+								color: var(--bg-neutral-text-#{$each}-hover);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
ISSUE: Resolves #57 

PROJECT: [Crio Issues](https://github.com/orgs/BoldGrid/projects/13/views/9?pane=issue&itemId=24264485)

# fix comment header being overridden by currentcolor #

## Test Files ##

[crio-2.22.1-issue-57.zip](https://github.com/BoldGrid/crio/files/14285043/crio-2.22.1-issue-57.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Install Crio Pro
3. Create a post with a comment.
4. Open the customizer, and change the heading background color to the neutral color.
5. Ensure that the Header link color still works as expected.
