### PR TITLE
Live preview changes Header Background of CPH when it should not

### DIFF
--- a/src/assets/js/customizer/customizer.js
+++ b/src/assets/js/customizer/customizer.js
@@ -583,7 +583,7 @@ BOLDGRID.Customizer.Util.getInitialPalettes = function( option ) {
 		/* Header Background Color */
 		api( 'bgtfw_header_color', function( value ) {
 			value.bind( function() {
-				colorPreview.outputColor( 'bgtfw_header_color', '#masthead, #navi, #masthead-sticky', [ 'background-color', 'text-default' ] );
+				colorPreview.outputColor( 'bgtfw_header_color', '#masthead:not(.template-header), #navi:not(.template-header), #masthead-sticky:not(.template-header)', [ 'background-color', 'text-default' ] );
 			} );
 		} );
 


### PR DESCRIPTION
ISSUE: Resolves #77 

PROJECT: [Crio Issues](https://github.com/orgs/BoldGrid/projects/13/views/9?pane=issue&itemId=28075700)

# Live preview changes Header Background of CPH when it should not #

## Test Files ##

[crio-2.22.1-issue-77.zip](https://github.com/BoldGrid/crio/files/14298625/crio-2.22.1-issue-77.zip)

## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Install Crio Pro
3. Set a CPH with a neutral bg color as the header.
4. Open the customizer, and navigate to Design > Header > Background
5. Change the background color option. This should NOT change the color of the CPH
