### PR TITLE
add sanitization for font sizes

### DIFF
--- a/src/assets/js/customizer/typography/preview.js
+++ b/src/assets/js/customizer/typography/preview.js
@@ -34,6 +34,21 @@ export class Preview {
 			base,
 			unit,
 			controlType;
+
+		var sanitizeFontSize = ( size ) => {
+			var sizeBase    = parseInt( size ),
+				sizeUnit    = size.replace( sizeBase, '' ),
+				sizeMatches = sizeUnit.match( /(em|ex|%|px|cm|mm|in|pt|pc|rem)/ );
+
+			if ( sizeUnit === '' ) {
+				sizeUnit = 'px';
+			}
+
+			sizeUnit = sizeMatches ? sizeMatches[0] : 'px';
+
+			return sizeBase + sizeUnit;
+		};
+
 		if ( _.isUndefined( to ) ) {
 			to = api( controlId )();
 		}
@@ -92,20 +107,6 @@ export class Preview {
 
 			// Selector lists are pulled from the customizer options matched to controlType.
 			} else if ( controlType === selector.type ) {
-				let sanitizeFontSize = ( size ) => {
-					var sizeBase    = parseInt( size ),
-						sizeUnit    = size.replace( sizeBase, '' ),
-						sizeMatches = sizeUnit.match( /(em|ex|%|px|cm|mm|in|pt|pc|rem)/ );
-
-					if ( sizeUnit === '' ) {
-						sizeUnit = 'px';
-					}
-
-					sizeUnit = sizeMatches ? sizeMatches[0] : 'px';
-
-					return sizeBase + sizeUnit;
-				};
-
 				css += rule + '{font-size:' + sanitizeFontSize( to['font-size'] ) + ';';
 				// Adds css for font variants.
 				if ( fontWeight && fontStyle ) {
@@ -124,18 +125,19 @@ export class Preview {
 		if ( controlType.includes( 'menu' ) ) {
 			let rule = controlType.replace( /_/g, '-' );
 				rule = rule.replace( 'menu-', '' );
-				rule = '#' + rule + '-menu li a';
+				rule = '#' + rule + '-menu li.menu-item > a';
+
+			css += rule + '{font-size:' + sanitizeFontSize( to['font-size'] ) + ';';
 			if ( fontWeight && fontStyle ) {
-				css += rule + '{';
 				css += 'font-style:' + fontStyle + ';';
-				css += 'font-weight:' + fontWeight + ';}';
+				css += 'font-weight:' + fontWeight + ';';
 			} else if ( fontWeight ) {
-				css += rule + '{';
-				css += 'font-weight:' + fontWeight + ';}';
+				css += 'font-weight:' + fontWeight + ';';
 			} else if ( fontStyle ) {
-				css += rule + '{';
-				css += 'font-style:' + fontStyle + ';}';
+				css += 'font-style:' + fontStyle + ';';
 			}
+
+			css += '}';
 		}
 
 		return css;

--- a/src/assets/js/customizer/typography/preview.js
+++ b/src/assets/js/customizer/typography/preview.js
@@ -92,19 +92,31 @@ export class Preview {
 
 			// Selector lists are pulled from the customizer options matched to controlType.
 			} else if ( controlType === selector.type ) {
+				let sanitizeFontSize = ( size ) => {
+					var sizeBase    = parseInt( size ),
+						sizeUnit    = size.replace( sizeBase, '' ),
+						sizeMatches = sizeUnit.match( /(em|ex|%|px|cm|mm|in|pt|pc|rem)/ );
 
+					if ( sizeUnit === '' ) {
+						sizeUnit = 'px';
+					}
+
+					sizeUnit = sizeMatches ? sizeMatches[0] : 'px';
+
+					return sizeBase + sizeUnit;
+				};
+
+				css += rule + '{font-size:' + sanitizeFontSize( to['font-size'] ) + ';';
 				// Adds css for font variants.
 				if ( fontWeight && fontStyle ) {
-					css += rule + '{';
 					css += 'font-style:' + fontStyle + ';';
-					css += 'font-weight:' + fontWeight + ';}';
+					css += 'font-weight:' + fontWeight + ';';
 				} else if ( fontWeight ) {
-					css += rule + '{';
-					css += 'font-weight:' + fontWeight + ';}';
+					css += 'font-weight:' + fontWeight + ';';
 				} else if ( fontStyle ) {
-					css += rule + '{';
-					css += 'font-style:' + fontStyle + ';}';
+					css += 'font-style:' + fontStyle + ';';
 				}
+				css += '}';
 			}
 		} );
 

--- a/src/includes/configs/customizer-options/typography.config.php
+++ b/src/includes/configs/customizer-options/typography.config.php
@@ -95,6 +95,16 @@ return array(
 			'round'  => 'ceil',
 			'amount' => 1,
 		),
+		'.bgc-heading.bgc-site-title, .bgc-heading.bgc-site-title:hover' => array(
+			'type'   => 'site_title',
+			'round'  => 'ceil',
+			'amount' => 1,
+		),
+		'.palette-primary .site-footer .site-title > a:hover, .palette-primary .site-header .site-title > a:hover' => array(
+			'type'   => 'site_title',
+			'round'  => 'ceil',
+			'amount' => 1,
+		),
 		'.site-branding .site-description, .bgc-tagline' => array(
 			'type'   => 'tagline',
 			'round'  => 'ceil',

--- a/src/includes/configs/customizer-options/typography.config.php
+++ b/src/includes/configs/customizer-options/typography.config.php
@@ -90,6 +90,16 @@ return array(
 			'round'  => 'floor',
 			'amount' => 1,
 		),
+		'.palette-primary .site-footer .site-title > a, .palette-primary .site-header .site-title > a' => array(
+			'type'   => 'site_title',
+			'round'  => 'ceil',
+			'amount' => 1,
+		),
+		'.site-branding .site-description, .bgc-tagline' => array(
+			'type'   => 'tagline',
+			'round'  => 'ceil',
+			'amount' => 1,
+		),
 	),
 	'responsive_font_controls' => array(
 		'bgtfw_body_font_size'                => array(

--- a/src/includes/configs/customizer/controls/buttons.controls.php
+++ b/src/includes/configs/customizer/controls/buttons.controls.php
@@ -149,18 +149,19 @@ return array(
 			),
 		),
 	),
-	'bgtfw_button_primary_typography'            => array(
-		'type'      => 'typography',
-		'transport' => 'auto',
-		'settings'  => 'bgtfw_button_primary_typography',
-		'label'     => esc_attr__( 'Primary Button Typography', 'crio' ),
-		'section'   => 'bgtfw_primary_button',
-		'default'   => $bgtfw_typography->default_button_typography( $bgtfw_configs ),
-		'priority'  => 10,
-		'output'    => $bgtfw_typography->get_typography_output(
+	'bgtfw_button_primary_typography'     => array(
+		'type'              => 'typography',
+		'transport'         => 'auto',
+		'settings'          => 'bgtfw_button_primary_typography',
+		'label'             => esc_attr__( 'Primary Button Typography', 'crio' ),
+		'section'           => 'bgtfw_primary_button',
+		'default'           => $bgtfw_typography->default_button_typography( $bgtfw_configs ),
+		'priority'          => 10,
+		'output'            => $bgtfw_typography->get_typography_output(
 			$bgtfw_configs,
 			'.palette-primary *:not( .menu-item ) > .button-primary'
 		),
+		'sanitize_callback' => array( $bgtfw_typography, 'sanitize_typography' ),
 	),
 	// Secondary Buttons.
 	'bgtfw_secondary_button_background' => array(
@@ -301,17 +302,18 @@ return array(
 			),
 		),
 	),
-	'bgtfw_button_secondary_typography'            => array(
-		'type'      => 'typography',
-		'transport' => 'auto',
-		'settings'  => 'bgtfw_button_secondary_typography',
-		'label'     => esc_attr__( 'Secondary Button Typography', 'crio' ),
-		'section'   => 'bgtfw_secondary_button',
-		'default'   => $bgtfw_typography->default_button_typography( $bgtfw_configs ),
-		'priority'  => 10,
-		'output'    => $bgtfw_typography->get_typography_output(
+	'bgtfw_button_secondary_typography'   => array(
+		'type'              => 'typography',
+		'transport'         => 'auto',
+		'settings'          => 'bgtfw_button_secondary_typography',
+		'label'             => esc_attr__( 'Secondary Button Typography', 'crio' ),
+		'section'           => 'bgtfw_secondary_button',
+		'default'           => $bgtfw_typography->default_button_typography( $bgtfw_configs ),
+		'priority'          => 10,
+		'output'            => $bgtfw_typography->get_typography_output(
 			$bgtfw_configs,
 			'.palette-primary *:not( .menu-item ) > .button-secondary'
 		),
+		'sanitize_callback' => array( $bgtfw_typography, 'sanitize_typography' ),
 	),
 );

--- a/src/includes/configs/customizer/controls/menu.controls.php
+++ b/src/includes/configs/customizer/controls/menu.controls.php
@@ -610,12 +610,12 @@ return array(
 
 	/** Menu Typography */
 	'bgtfw_menu_typography_main'                      => array(
-		'type'      => 'typography',
-		'transport' => 'auto',
-		'settings'  => 'bgtfw_menu_typography_main',
-		'label'     => esc_attr__( 'Typography', 'crio' ),
-		'section'   => 'bgtfw_menu_typography_main',
-		'default'   => array(
+		'type'              => 'typography',
+		'transport'         => 'auto',
+		'settings'          => 'bgtfw_menu_typography_main',
+		'label'             => esc_attr__( 'Typography', 'crio' ),
+		'section'           => 'bgtfw_menu_typography_main',
+		'default'           => array(
 			'font-family'    => 'Roboto',
 			'variant'        => 'regular',
 			'font-size'      => '18px',
@@ -624,10 +624,11 @@ return array(
 			'subsets'        => array( 'latin-ext' ),
 			'text-transform' => 'uppercase',
 		),
-		'priority'  => 20,
-		'output'    => $bgtfw_typography->get_typography_output(
+		'priority'          => 20,
+		'output'            => $bgtfw_typography->get_typography_output(
 			$bgtfw_configs,
 			'#main-menu li.menu-item > a, .mce-content-body .sm-clean'
 		),
+		'sanitize_callback' => array( $bgtfw_typography, 'sanitize_typography' ),
 	),
 );

--- a/src/includes/configs/customizer/controls/title-tagline.controls.php
+++ b/src/includes/configs/customizer/controls/title-tagline.controls.php
@@ -26,12 +26,12 @@ return array(
 		'sanitize_callback' => array( $bgtfw_color_sanitize, 'sanitize_palette_selector' ),
 	),
 	'bgtfw_site_title_typography' => array(
-		'type'      => 'typography',
-		'transport' => 'auto',
-		'settings'  => 'bgtfw_site_title_typography',
-		'label'     => esc_attr__( 'Typography', 'crio' ),
-		'section'   => 'bgtfw_site_title',
-		'default'   => array(
+		'type'              => 'typography',
+		'transport'         => 'auto',
+		'settings'          => 'bgtfw_site_title_typography',
+		'label'             => esc_attr__( 'Typography', 'crio' ),
+		'section'           => 'bgtfw_site_title',
+		'default'           => array(
 			'font-family'    => 'Roboto',
 			'variant'        => 'regular',
 			'font-size'      => '42px',
@@ -41,11 +41,12 @@ return array(
 			'text-transform' => 'none',
 			'text-align'     => 'left',
 		),
-		'priority'  => 20,
-		'output'    => $bgtfw_typography->get_typography_output(
+		'priority'          => 20,
+		'output'            => $bgtfw_typography->get_typography_output(
 			$bgtfw_configs,
 			'.site-footer .site-title > a, .' . get_theme_mod( 'boldgrid_palette_class', 'palette-primary' ) . '.site-header .site-title > a, .' . get_theme_mod( 'boldgrid_palette_class', 'palette-primary' ) . ' .site-header .site-title > a,.' . get_theme_mod( 'boldgrid_palette_class', 'palette-primary' ) . ' .site-header .site-title > a:hover, .bgc-heading.bgc-site-title, .bgc-heading.bgc-site-title:hover'
 		),
+		'sanitize_callback' => array( $bgtfw_typography, 'sanitize_typography' ),
 	),
 	'bgtfw_tagline_color'         => array(
 		'type'              => 'bgtfw-palette-selector',
@@ -62,12 +63,12 @@ return array(
 		'sanitize_callback' => array( $bgtfw_color_sanitize, 'sanitize_palette_selector' ),
 	),
 	'bgtfw_tagline_typography'    => array(
-		'type'      => 'typography',
-		'transport' => 'auto',
-		'settings'  => 'bgtfw_tagline_typography',
-		'label'     => esc_attr__( 'Typography', 'crio' ),
-		'section'   => 'bgtfw_tagline',
-		'default'   => array(
+		'type'              => 'typography',
+		'transport'         => 'auto',
+		'settings'          => 'bgtfw_tagline_typography',
+		'label'             => esc_attr__( 'Typography', 'crio' ),
+		'section'           => 'bgtfw_tagline',
+		'default'           => array(
 			'font-family'    => 'Roboto',
 			'variant'        => 'regular',
 			'font-size'      => '42px',
@@ -77,10 +78,11 @@ return array(
 			'text-transform' => 'none',
 			'text-align'     => 'left',
 		),
-		'priority'  => 20,
-		'output'    => $bgtfw_typography->get_typography_output(
+		'priority'          => 20,
+		'output'            => $bgtfw_typography->get_typography_output(
 			$bgtfw_configs,
 			'.site-branding .site-description, .bgc-tagline'
 		),
+		'sanitize_callback' => array( $bgtfw_typography, 'sanitize_typography' ),
 	),
 );

--- a/src/includes/configs/customizer/controls/typography.controls.php
+++ b/src/includes/configs/customizer/controls/typography.controls.php
@@ -26,12 +26,12 @@ return array(
 		'sanitize_callback' => array( $bgtfw_color_sanitize, 'sanitize_palette_selector' ),
 	),
 	'bgtfw_headings_typography'        => array(
-		'type'      => 'typography',
-		'settings'  => 'bgtfw_headings_typography',
-		'transport' => 'auto',
-		'label'     => esc_attr__( 'Headings Typography', 'crio' ),
-		'section'   => 'boldgrid_typography',
-		'default'   => array(
+		'type'              => 'typography',
+		'settings'          => 'bgtfw_headings_typography',
+		'transport'         => 'auto',
+		'label'             => esc_attr__( 'Headings Typography', 'crio' ),
+		'section'           => 'boldgrid_typography',
+		'default'           => array(
 			'font-family'    => 'Roboto',
 			'variant'        => 'regular',
 			'line-height'    => '1.5',
@@ -39,15 +39,16 @@ return array(
 			'subsets'        => array( 'latin-ext' ),
 			'text-transform' => 'none',
 		),
-		'priority'  => 3,
-		'output'    => $bgtfw_typography->get_output_values( $bgtfw_configs ),
-		'edit_vars' => array(
+		'priority'          => 3,
+		'output'            => $bgtfw_typography->get_output_values( $bgtfw_configs ),
+		'edit_vars'         => array(
 			array(
 				'selector'    => array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ),
 				'label'       => esc_attr__( 'Heading Typography', 'crio' ),
 				'description' => esc_attr__( 'Adjust heading typography styles', 'crio' ),
 			),
 		),
+		'sanitize_callback' => array( $bgtfw_typography, 'sanitize_typography' ),
 	),
 	'bgtfw_headings_font_size'         => array(
 		'type'      => 'text',
@@ -60,12 +61,12 @@ return array(
 		'sanitize_callback' => array( $bgtfw_typography, 'sanitize_font_size' ),
 	),
 	'bgtfw_body_typography'            => array(
-		'type'      => 'typography',
-		'transport' => 'auto',
-		'settings'  => 'bgtfw_body_typography',
-		'label'     => esc_attr__( 'Main Text Typography', 'crio' ),
-		'section'   => 'boldgrid_typography',
-		'default'   => array(
+		'type'              => 'typography',
+		'transport'         => 'auto',
+		'settings'          => 'bgtfw_body_typography',
+		'label'             => esc_attr__( 'Main Text Typography', 'crio' ),
+		'section'           => 'boldgrid_typography',
+		'default'           => array(
 			'font-family'    => 'Roboto',
 			'variant'        => '100',
 			'font-size'      => '18px',
@@ -74,12 +75,13 @@ return array(
 			'subsets'        => array( 'latin-ext' ),
 			'text-transform' => 'none',
 		),
-		'priority'  => 1,
-		'output'    => $bgtfw_typography->get_typography_output(
+		'priority'          => 1,
+		'output'            => $bgtfw_typography->get_typography_output(
 			$bgtfw_configs,
 			'.widget, .site-content, .sm li.custom-sub-menu, .sm li.custom-sub-menu a:not(.btn), .sm li.custom-sub-menu .widget a:not(.btn), .attribution-theme-mods-wrapper, .gutenberg .edit-post-visual-editor, .mce-content-body, .template-header, .template-sticky-header, .template-footer'
 		),
-		'edit_vars' => array(
+		'sanitize_callback' => array( $bgtfw_typography, 'sanitize_typography' ),
+		'edit_vars'         => array(
 			array(
 				'selector'    => array(
 					'.site-content p:first-of-type',

--- a/src/includes/configs/customizer/controls/typography.controls.php
+++ b/src/includes/configs/customizer/controls/typography.controls.php
@@ -48,7 +48,6 @@ return array(
 				'description' => esc_attr__( 'Adjust heading typography styles', 'crio' ),
 			),
 		),
-		'sanitize_callback' => array( $bgtfw_typography, 'sanitize_typography' ),
 	),
 	'bgtfw_headings_font_size'         => array(
 		'type'      => 'text',

--- a/src/includes/customizer/class-boldgrid-framework-customizer-typography.php
+++ b/src/includes/customizer/class-boldgrid-framework-customizer-typography.php
@@ -295,6 +295,33 @@ class Boldgrid_Framework_Customizer_Typography {
 	}
 
 	/**
+	 * Sanitize Typography Controls.
+	 *
+	 * Sanitize callback for typography sanitize_callback argument.
+	 *
+	 * @since 2.22.1
+	 *
+	 * @param array $value The value to sanitize.
+	 *
+	 * @return string Sanitized value.
+	 */
+	public function sanitize_typography( $value ) {
+
+		if ( ! is_array( $value ) ) {
+			return false;
+		}
+		if ( ! isset( $value['font-size'] ) ) {
+			return false;
+		}
+
+		$font_size = $this->sanitize_font_size( $value['font-size'] );
+
+		$value['font-size'] = $font_size;
+
+		return $value;
+	}
+
+	/**
 	 * Sanitize Responsive Fonts.
 	 *
 	 * Sanitize callback for responsive fonts validate_callback argument.


### PR DESCRIPTION
ISSUE: Resolves #112 

PROJECT: [Crio Issues](https://github.com/orgs/BoldGrid/projects/13/views/9?pane=issue&itemId=53522116)

# add sanitization for font sizes #

## Test Files ##

[crio-2.22.1-issue-112.zip](https://github.com/BoldGrid/crio/files/14410230/crio-2.22.1-issue-112.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Open the Customizer.
3. Pick a typography control other than the 'Headings Font' since that uses a different method of calculation font sizes.
4. Enter a font size without a unit( ie 42 instead of 42px )
5. Ensure that the font size in the preview changes to automatically add the 'px' unit.
6. Try a few other units, such as pt, em, rem, etc and ensure that they work.
7. Publish the changes with no unit set. 
8. Refresh / Reopen the customizer, and ensure that the value saved has the 'px' unit added.
