### PR TITLE
fix Footer Widgets - content inherits Headings Color #86

### DIFF
--- a/src/includes/customizer/class-boldgrid-framework-customizer-widget-meta.php
+++ b/src/includes/customizer/class-boldgrid-framework-customizer-widget-meta.php
@@ -384,6 +384,12 @@ class Boldgrid_Framework_Customizer_Widget_Meta {
 
 			foreach ( $this->configs['customizer-options']['typography']['selectors'] as $selector => $options ) {
 				$exploded = explode( ',', $selector );
+
+				// Only add selectors for headings.
+				if ( 'headings' !== $options['type'] ) {
+					continue;
+				}
+
 				foreach ( $exploded as $explode ) {
 					$selectors[] = ".{$sidebar_id} {$explode}";
 				}


### PR DESCRIPTION
ISSUE: Resolves #86 

PROJECT: [Crio Issues](https://github.com/orgs/BoldGrid/projects/13/views/9?pane=issue&itemId=29264488)

# Fix Footer Widgets #

## Test Files ##

[crio-2.22.1-issue-86.zip](https://github.com/BoldGrid/crio/files/14407840/crio-2.22.1-issue-86.zip)

## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Start with Starter Content
3. Change color palette
4. Change the background of a footer widget
5. Change the Headings Color in a footer widget Column 1
6. Publish the Customizer and view the front end
7. Ensure that the Heading text color updates to match what you set, and that the widget content text does not inherit the heading color
