### PR TITLE
update woo templates

### DIFF
--- a/prime/woocommerce/archive-product.php
+++ b/prime/woocommerce/archive-product.php
@@ -10,14 +10,10 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
- * @version 3.4.0
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates
+ * @version 8.6.0
  */
-
-$has_header_template = apply_filters( 'crio_premium_get_page_header', get_the_ID() );
-$has_header_template = get_the_ID() === $has_header_template ? false : $has_header_template;
-$template_has_title  = get_post_meta( $has_header_template, 'crio-premium-template-has-page-title', true );
 
 defined( 'ABSPATH' ) || exit;
 
@@ -32,23 +28,15 @@ get_header( 'shop' );
  */
 do_action( 'woocommerce_before_main_content' );
 
-?>
-<header class="woocommerce-products-header">
-	<?php if ( apply_filters( 'woocommerce_show_page_title', true ) && ! $template_has_title ) : ?>
-		<<?php echo is_front_page() ? 'h2' : 'h1'; ?> class="woocommerce-products-header__title page-title"><?php woocommerce_page_title(); ?></h1>
-	<?php endif; ?>
+/**
+ * Hook: woocommerce_shop_loop_header.
+ *
+ * @since 8.6.0
+ *
+ * @hooked woocommerce_product_taxonomy_archive_header - 10
+ */
+do_action( 'woocommerce_shop_loop_header' );
 
-	<?php
-	/**
-	 * Hook: woocommerce_archive_description.
-	 *
-	 * @hooked woocommerce_taxonomy_archive_description - 10
-	 * @hooked woocommerce_product_archive_description - 10
-	 */
-	do_action( 'woocommerce_archive_description' );
-	?>
-</header>
-<?php
 if ( woocommerce_product_loop() ) {
 
 	/**

--- a/prime/woocommerce/myaccount/form-edit-account.php
+++ b/prime/woocommerce/myaccount/form-edit-account.php
@@ -11,9 +11,9 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see https://docs.woocommerce.com/document/template-structure/
+ * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.0.1
+ * @version 8.7.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -44,6 +44,14 @@ do_action( 'woocommerce_before_edit_account_form' ); ?>
 		<label for="account_email"><?php esc_html_e( 'Email address', 'crio' ); ?>&nbsp;<span class="required">*</span></label>
 		<input type="email" class="woocommerce-Input woocommerce-Input--email input-text form-control input-lg" name="account_email" id="account_email" autocomplete="email" value="<?php echo esc_attr( $user->user_email ); ?>" />
 	</p>
+	<?php
+		/**
+		 * Hook where additional fields should be rendered.
+		 *
+		 * @since 8.7.0
+		 */
+		do_action( 'woocommerce_edit_account_form_fields' );
+	?>
 
 	<fieldset>
 		<legend class="h3"><?php esc_html_e( 'Password change', 'crio' ); ?></legend>
@@ -63,7 +71,14 @@ do_action( 'woocommerce_before_edit_account_form' ); ?>
 	</fieldset>
 	<div class="clear"></div>
 
-	<?php do_action( 'woocommerce_edit_account_form' ); ?>
+	<?php
+		/**
+		 * My Account edit account form.
+		 *
+		 * @since 2.6.0
+		 */
+		do_action( 'woocommerce_edit_account_form' );
+	?>
 
 	<p>
 		<?php wp_nonce_field( 'save_account_details', 'save-account-details-nonce' ); ?>

--- a/prime/woocommerce/myaccount/navigation.php
+++ b/prime/woocommerce/myaccount/navigation.php
@@ -27,7 +27,7 @@ do_action( 'woocommerce_before_account_navigation' );
 
 		<?php foreach ( wc_get_account_menu_items() as $endpoint => $label ) : ?>
 			<?php $classes = wc_get_account_menu_item_classes( $endpoint ); ?>
-			<li class="<?php echo esc_attr( $endpoint ); ?>">
+			<li class="<?php echo esc_attr( $classes ); ?>">
 			<?php
 				$active = '';
 				if ( strpos( $classes, 'is-active' ) !== false ) {

--- a/prime/woocommerce/myaccount/navigation.php
+++ b/prime/woocommerce/myaccount/navigation.php
@@ -26,7 +26,8 @@ do_action( 'woocommerce_before_account_navigation' );
 	<ul class="nav nav-pills nav-stacked">
 
 		<?php foreach ( wc_get_account_menu_items() as $endpoint => $label ) : ?>
-			<li class="<?php echo esc_attr( wc_get_account_menu_item_classes( $endpoint ) ); ?>">
+			<?php $classes = wc_get_account_menu_item_classes( $endpoint ); ?>
+			<li class="<?php echo esc_attr( $endpoint ); ?>">
 			<?php
 				$active = '';
 				if ( strpos( $classes, 'is-active' ) !== false ) {

--- a/prime/woocommerce/myaccount/navigation.php
+++ b/prime/woocommerce/myaccount/navigation.php
@@ -10,10 +10,9 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see     https://docs.woocommerce.com/document/template-structure/
- * @author  WooThemes
- * @package WooCommerce/Templates
- * @version 2.6.0
+ * @see     https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates
+ * @version 9.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -23,12 +22,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 do_action( 'woocommerce_before_account_navigation' );
 ?>
 
-<nav class="woocommerce-MyAccount-navigation">
+<nav class="woocommerce-MyAccount-navigation" aria-label="<?php esc_html_e( 'Account pages', 'crio' ); ?>">
 	<ul class="nav nav-pills nav-stacked">
 
 		<?php foreach ( wc_get_account_menu_items() as $endpoint => $label ) : ?>
-			<?php $classes = wc_get_account_menu_item_classes( $endpoint ); ?>
-			<li class="<?php echo esc_attr( $classes ); ?>">
+			<li class="<?php echo esc_attr( wc_get_account_menu_item_classes( $endpoint ) ); ?>">
 			<?php
 				$active = '';
 				if ( strpos( $classes, 'is-active' ) !== false ) {

--- a/prime/woocommerce/myaccount/orders.php
+++ b/prime/woocommerce/myaccount/orders.php
@@ -12,9 +12,9 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see https://woo.com/document/template-structure/
+ * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 8.5.0
+ * @version 9.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -45,7 +45,8 @@ do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
 								<?php do_action( 'woocommerce_my_account_my_orders_column_' . $column_id, $order ); ?>
 
 							<?php elseif ( 'order-number' === $column_id ) : ?>
-								<a href="<?php echo esc_url( $order->get_view_order_url() ); ?>">
+								<?php /* translators: %s: the order number, usually accompanied by a leading # */ ?>
+								<a href="<?php echo esc_url( $order->get_view_order_url() ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'View order number %s', 'crio' ), $order->get_order_number() ) ); ?>">
 									<?php echo esc_html( _x( '#', 'hash before order number', 'crio' ) . $order->get_order_number() ); ?>
 								</a>
 


### PR DESCRIPTION
ISSUE: Resolves #127 

# Update WooCommerce Templates#

## Test Files ##

[crio-2.22.4-issue-127.zip](https://github.com/user-attachments/files/16338283/crio-2.22.4-issue-127.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Install WooCommerce and sample products.
3. Verify that the template versions are not out of date in the dashboard ( WooCommerce > Status ).
4. Visit a shop archive page, such as the main shop page, or a category page, and ensure that everything displays as expected.
5. Visit the 'My Account' page, and make sure that everything appears as expected.
6. Visit the "Account Details" page, and make sure the input fields appear as expected.
7. Visit the 'Orders' page, and make sure everything appears as expected.
